### PR TITLE
Add support for a logo in the NavBar

### DIFF
--- a/amundsen_application/static/config/config-default.ts
+++ b/amundsen_application/static/config/config-default.ts
@@ -22,6 +22,7 @@ const configDefault: AppConfig = {
     },
     iconPath: 'PATH_TO_ICON'
   },
+  logoPath: null,
   navLinks: [
     {
       label: "Announcements",

--- a/amundsen_application/static/config/config.types.ts
+++ b/amundsen_application/static/config/config.types.ts
@@ -9,6 +9,7 @@ export interface AppConfig {
   exploreSql: ExploreSqlConfig;
   google: GoogleAnalyticsConfig;
   lineage: LineageConfig;
+  logoPath: string | null;
   navLinks: Array<LinkConfig>;
 }
 
@@ -17,6 +18,7 @@ export interface AppConfigCustom {
   exploreSql?: ExploreSqlConfig;
   google?: GoogleAnalyticsConfig
   lineage?: LineageConfig;
+  logoPath?: string;
   navLinks?: Array<LinkConfig>;
 }
 

--- a/amundsen_application/static/js/components/NavBar/index.tsx
+++ b/amundsen_application/static/js/components/NavBar/index.tsx
@@ -53,7 +53,7 @@ class NavBar extends React.Component<NavBarProps, NavBarState> {
             <div className="nav-bar-left">
               {
                 AppConfig.logoPath &&
-                <img src={AppConfig.logoPath} />
+                <img className="logo-icon" src={AppConfig.logoPath} />
               }
               <Link to={`/`}>
                 AMUNDSEN

--- a/amundsen_application/static/js/components/NavBar/index.tsx
+++ b/amundsen_application/static/js/components/NavBar/index.tsx
@@ -51,6 +51,10 @@ class NavBar extends React.Component<NavBarProps, NavBarState> {
         <div className="row">
           <div className="nav-bar">
             <div className="nav-bar-left">
+              {
+                AppConfig.logoPath &&
+                <img src={AppConfig.logoPath} />
+              }
               <Link to={`/`}>
                 AMUNDSEN
               </Link>

--- a/amundsen_application/static/js/components/NavBar/styles.scss
+++ b/amundsen_application/static/js/components/NavBar/styles.scss
@@ -34,8 +34,12 @@
   margin-left: auto;
   display: flex;
 }
+.nav-bar-left > *,
 .nav-bar-right > * {
   margin: auto 10px;
+}
+.nav-bar-left > *:first-child {
+  margin-left: 0px;
 }
 .nav-bar-right > *:last-child {
   margin-right: 0px;

--- a/amundsen_application/static/js/components/NavBar/styles.scss
+++ b/amundsen_application/static/js/components/NavBar/styles.scss
@@ -54,3 +54,8 @@
 .sb-avatar > div {
   border: 1px solid white;
 }
+
+.logo-icon {
+  max-height: 48px;
+  max-width: 144px;
+}


### PR DESCRIPTION
This PR adds support for customizable logo in the `NavBar`.  

**Summary of Changes**
1. A `logoPath` option was added to the application configuration, which is `null` by default until we have the design resources for an official Amundsen logo. If a `logoPath` exists, it will render it on the left hand side of the `NavBar`. We do not have any checks/fallbacks for a bad path -- this implementation expects that if a `logoPath` is configured, it is valid.

2. CSS has also been updated accordingly to space the items in `.nav-bar-left`  in the same way they are spaced in `.nav-bar-right`

