### PR TITLE
Add re-useable Flag component

### DIFF
--- a/amundsen_application/static/css/_variables-default.scss
+++ b/amundsen_application/static/css/_variables-default.scss
@@ -56,3 +56,7 @@ $btn-primary-color:  $text-color;
 // List Group
 $list-group-border:        $gray-lighter;
 $list-group-border-radius: 0;
+
+
+// Labels
+$label-primary-bg:  $gradient-3;

--- a/amundsen_application/static/js/components/TableDetail/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/styles.scss
@@ -30,7 +30,7 @@
   font-weight: $font-weight-sans-serif-bold;
 }
 
-.detail-list-header label{
+.detail-list-header > label {
   font-size: 20px;
   margin-top: auto;
   margin-bottom: 32px;

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -5,20 +5,18 @@ import './styles.scss';
 
 interface FlagProps {
   text: string;
+  style?: string;
 }
 
-const Flag: React.SFC<FlagProps> = ({ text }) => {
-
+const Flag: React.SFC<FlagProps> = ({ text, style }) => {
   return (
-    <div className='flag-component'>
-      <label>{text.toUpperCase()}</label>
-    </div>
+    <span className={`flag label ${style}`}>{text.toUpperCase()}</span>
   );
-
 };
 
 Flag.defaultProps = {
   text: '',
+  style: 'label-default',
 };
 
 export default Flag;

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+// TODO: Use css-modules instead of 'import'
+import './styles.scss';
+
+interface FlagProps {
+  text: string;
+}
+
+const Flag: React.SFC<FlagProps> = ({ text }) => {
+
+  return (
+    <div className='flag-component'>
+      <label>{text.toUpperCase()}</label>
+    </div>
+  );
+
+};
+
+Flag.defaultProps = {
+  text: '',
+};
+
+export default Flag;

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -5,18 +5,20 @@ import './styles.scss';
 
 interface FlagProps {
   text: string;
-  style?: string;
+  labelStyle?: string;
 }
 
-const Flag: React.SFC<FlagProps> = ({ text, style }) => {
+const Flag: React.SFC<FlagProps> = ({ text, labelStyle }) => {
+  // TODO: After upgrading to Bootstrap 4, this component should leverage badges
+  // https://getbootstrap.com/docs/4.1/components/badge/
   return (
-    <span className={`flag label ${style}`}>{text.toUpperCase()}</span>
+    <span className={`flag label ${labelStyle}`}>{text.toUpperCase()}</span>
   );
 };
 
 Flag.defaultProps = {
   text: '',
-  style: 'label-default',
+  labelStyle: 'label-default',
 };
 
 export default Flag;

--- a/amundsen_application/static/js/components/common/Flag/styles.scss
+++ b/amundsen_application/static/js/components/common/Flag/styles.scss
@@ -1,0 +1,14 @@
+@import 'variables';
+
+.flag-component {
+  label {
+    background-color: $gray-lighter;
+    border-radius: 4px;
+    color: $gray-darker;
+    font-size: 10px;
+    line-height: 16px;
+    margin-right: 4px;
+    margin-left: 4px;
+    padding: 2px 8px;
+  }
+}

--- a/amundsen_application/static/js/components/common/Flag/styles.scss
+++ b/amundsen_application/static/js/components/common/Flag/styles.scss
@@ -3,5 +3,4 @@
 .flag {
   margin-right: 4px;
   margin-left: 4px;
-  line-height: 16px;
 }

--- a/amundsen_application/static/js/components/common/Flag/styles.scss
+++ b/amundsen_application/static/js/components/common/Flag/styles.scss
@@ -1,14 +1,7 @@
 @import 'variables';
 
-.flag-component {
-  label {
-    background-color: $gray-lighter;
-    border-radius: 4px;
-    color: $gray-darker;
-    font-size: 10px;
-    line-height: 16px;
-    margin-right: 4px;
-    margin-left: 4px;
-    padding: 2px 8px;
-  }
+.flag {
+  margin-right: 4px;
+  margin-left: 4px;
+  line-height: 16px;
 }


### PR DESCRIPTION
This PR adds a `Flag` component, which will be needed for upcoming features. The default color is dark text on light gray text. Colors can be customized with css by overriding `color` and `background-color` on the component.

**Examples**
<img width="221" alt="screen shot 2019-02-26 at 12 07 50 pm" src="https://user-images.githubusercontent.com/1790900/53443147-dbc26e00-39bf-11e9-8f61-64b4e90b0606.png">

Also noticed the need for css tweak for `.detail-list-header` when testing this.