### PR TITLE
Add shared button styles + modify tag modal to match owner modal

### DIFF
--- a/amundsen_application/static/css/_buttons-default.scss
+++ b/amundsen_application/static/css/_buttons-default.scss
@@ -41,11 +41,12 @@
     }
   }
 
-  &.btn-icon {
+  &.btn-flat-icon {
     border: none;
     color: $gray-light;
-    -webkit-box-shadow: none !important;
     box-shadow: none !important;
+    padding: 0px;
+    text-align: left;
 
     &:focus,
     &:not(.disabled):hover,
@@ -58,7 +59,7 @@
       }
     }
   }
-  
+
   &.btn-primary {
     border-width: 2px;
     -webkit-box-shadow: 8px 9px 20px -15px rgba(0,0,0,0.46);

--- a/amundsen_application/static/css/_buttons-default.scss
+++ b/amundsen_application/static/css/_buttons-default.scss
@@ -28,6 +28,37 @@
     margin-bottom: 4px;
   }
 
+  &.btn-cancel {
+    border-color: $gray-lighter;
+    font-family: $font-family-sans-serif-bold;
+    font-weight: $font-weight-sans-serif-bold;
+
+    &:focus,
+    &:not(.disabled):hover,
+    &:not([disabled]):hover {
+      background-color: $gray-lighter;
+      border-color: $gray-lighter;
+    }
+  }
+
+  &.btn-icon {
+    border: none;
+    color: $gray-light;
+    -webkit-box-shadow: none !important;
+    box-shadow: none !important;
+
+    &:focus,
+    &:not(.disabled):hover,
+    &:not([disabled]):hover {
+      background-color: transparent;
+      color: $gradient-4;
+
+      .icon {
+        background-color: $gradient-4;
+      }
+    }
+  }
+  
   &.btn-primary {
     border-width: 2px;
     -webkit-box-shadow: 8px 9px 20px -15px rgba(0,0,0,0.46);
@@ -35,6 +66,22 @@
     box-shadow: 8px 9px 20px -15px rgba(0,0,0,0.46);
     font-family: $font-family-sans-serif-bold;
     font-weight: $font-weight-sans-serif-bold;
+  }
+
+  &.btn-save {
+    color: white;
+    background-color: $gradient-4;
+    border-color: $gradient-4;
+    font-family: $font-family-sans-serif-bold;
+    font-weight: $font-weight-sans-serif-bold;
+
+    &:focus,
+    &:not(.disabled):hover,
+    &:not([disabled]):hover {
+      color: white;
+      background-color: $gradient-5;
+      border-color: $gradient-5;
+    }
   }
 
   &.disabled,

--- a/amundsen_application/static/js/components/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/OwnerEditor/index.tsx
@@ -156,7 +156,7 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
                 <li key={`modal-list-item:${key}`}>
                   { React.createElement(AvatarLabel, this.state.tempItemProps[key]) }
                   <button
-                    className='btn btn-icon delete-button'
+                    className='btn btn-flat-icon delete-button'
                     aria-label='Delete Item'
                     /* tslint:disable - TODO: Investigate jsx-no-lambda rule */
                     onClick={() => this.recordDeleteItem(key)}
@@ -209,7 +209,7 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
         {
           !this.state.readOnly &&
           <button
-           className='btn btn-icon add-item-button'
+           className='btn btn-flat-icon add-item-button'
            onClick={this.handleShow}>
              <img className='icon icon-plus-circle'/>
              <span>Add</span>

--- a/amundsen_application/static/js/components/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/OwnerEditor/index.tsx
@@ -145,7 +145,7 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
             placeholder='Enter an email address'
             ref={ this.inputRef }
           />
-          <button className="btn btn-light add-btn" type="submit" aria-label="Add Item">
+          <button className="btn btn-light add-button" type="submit" aria-label="Add Item">
             <span aria-hidden="true">Add</span>
           </button>
         </form>
@@ -156,7 +156,7 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
                 <li key={`modal-list-item:${key}`}>
                   { React.createElement(AvatarLabel, this.state.tempItemProps[key]) }
                   <button
-                    className='btn delete-button'
+                    className='btn btn-icon delete-button'
                     aria-label='Delete Item'
                     /* tslint:disable - TODO: Investigate jsx-no-lambda rule */
                     onClick={() => this.recordDeleteItem(key)}
@@ -209,7 +209,7 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
         {
           !this.state.readOnly &&
           <button
-           className='btn add-list-item'
+           className='btn btn-icon add-item-button'
            onClick={this.handleShow}>
              <img className='icon icon-plus-circle'/>
              <span>Add</span>
@@ -222,8 +222,8 @@ class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorState> {
           </Modal.Header>
           { this.renderModalBody() }
           <Modal.Footer>
-            <button type="button" className="btn cancel-btn" onClick={this.cancelEdit}>Cancel</button>
-            <button type="button" className="btn save-btn" onClick={this.saveEdit}>Save</button>
+            <button type="button" className="btn btn-cancel" onClick={this.cancelEdit}>Cancel</button>
+            <button type="button" className="btn btn-save" onClick={this.saveEdit}>Save</button>
           </Modal.Footer>
         </Modal>
       </div>

--- a/amundsen_application/static/js/components/OwnerEditor/styles.scss
+++ b/amundsen_application/static/js/components/OwnerEditor/styles.scss
@@ -4,9 +4,8 @@
 
 .owner-editor-component {
   .btn.add-item-button {
-    padding: 4px 1px;
-    text-align: left;
     height: 32px;
+    padding: 0px 1px;
   }
 
   label {
@@ -33,11 +32,8 @@
     }
 
     .btn.delete-button {
-      height: 24px;
-      width: 24px;
       margin: auto;
       margin-right: 0px;
-      padding: 0;
       display: none;
     }
   }

--- a/amundsen_application/static/js/components/OwnerEditor/styles.scss
+++ b/amundsen_application/static/js/components/OwnerEditor/styles.scss
@@ -3,25 +3,10 @@
 @import 'variables';
 
 .owner-editor-component {
-  .btn.add-list-item {
-    color: $gray-light;
+  .btn.add-item-button {
     padding: 4px 1px;
-    -webkit-box-shadow: none !important;
-    box-shadow: none !important;
     text-align: left;
     height: 32px;
-
-    &:focus,
-    &:not(.disabled):hover,
-    &:not([disabled]):hover {
-      color: $gradient-4;
-      background-color: transparent;
-      border-color: transparent;
-
-      .icon {
-        background-color: $gradient-4;
-      }
-    }
   }
 
   label {
@@ -42,7 +27,8 @@
       background-color: $gray-lightest;
 
       .btn.delete-button {
-        display: block;
+        background-color: $gray-lightest;
+        display: block
       }
     }
 
@@ -53,19 +39,6 @@
       margin-right: 0px;
       padding: 0;
       display: none;
-      background-color: transparent;
-      border: none;
-
-      &:focus,
-      &:not(.disabled):hover,
-      &:not([disabled]):hover {
-        background-color: transparent;
-        border-color: transparent;
-
-        .icon {
-          background-color: $gradient-4;
-        }
-      }
     }
   }
 
@@ -73,34 +46,7 @@
     margin-top: auto;
   }
 
-  .btn.save-btn {
-    color: white;
-    background-color: $gradient-4;
-    border-color: $gradient-4;
-    font-family: $font-family-sans-serif-bold;
-    font-weight: $font-weight-sans-serif-bold;
-
-
-    &:focus,
-    &:not(.disabled):hover,
-    &:not([disabled]):hover {
-      color: white;
-      background-color: $gradient-5;
-      border-color: $gradient-5;
-    }
-  }
-  .btn.cancel-btn {
-    border-color: $gray-lighter;
-    font-family: $font-family-sans-serif-bold;
-    font-weight: $font-weight-sans-serif-bold;
-
-    &:focus,
-    &:not(.disabled):hover,
-    &:not([disabled]):hover {
-      background-color: $gray-lighter;
-    }
-  }
-  .btn.add-btn {
+  .btn.add-button {
     margin-left: 8px;
   }
 

--- a/amundsen_application/static/js/components/Tags/TagInput/index.tsx
+++ b/amundsen_application/static/js/components/Tags/TagInput/index.tsx
@@ -270,15 +270,15 @@ class TagInput extends React.Component<TagInputProps, TagInputState> {
       <div className='tag-input'>
         { tagBody }
         <Modal className='tag-input-modal' show={this.state.showModal} onHide={this.handleClose}>
-          <Modal.Header className="text-center" closeButton={true}>
+          <Modal.Header className="text-center" closeButton={false}>
             <Modal.Title>Add/Remove Tags</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             {this.renderModalBody()}
           </Modal.Body>
           <Modal.Footer>
-            <button type="button" className="btn btn-light" onClick={this.handleSaveModalEdit}>Save</button>
-            <button type="button" className="btn btn-light" onClick={this.handleClose}>Cancel</button>
+            <button type="button" className="btn btn-cancel" onClick={this.handleClose}>Cancel</button>
+            <button type="button" className="btn btn-save" onClick={this.handleSaveModalEdit}>Save</button>
           </Modal.Footer>
         </Modal>
       </div>

--- a/amundsen_application/static/js/components/Tags/TagInput/styles.scss
+++ b/amundsen_application/static/js/components/Tags/TagInput/styles.scss
@@ -93,8 +93,4 @@
       margin-left: 4px;
     }
   }
-
-  .modal-footer button:hover {
-    background-color: $gray-lighter;
-  }
 }

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -13,7 +13,7 @@ const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
   return (
     <div className='avatar-label-component'>
       <div className='component-avatar'>
-        <Avatar name={label} src={src} size={25} round={true} />
+        <Avatar name={label} src={src} size={24} round={true} />
       </div>
       <label className='component-label'>{label}</label>
     </div>

--- a/amundsen_application/static/js/components/common/AvatarLabel/styles.scss
+++ b/amundsen_application/static/js/components/common/AvatarLabel/styles.scss
@@ -3,7 +3,6 @@
 .avatar-label-component {
   display: flex;
   font-size: 12px;
-  width: 80%;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
In this PR I added 3 new specifications to the button configurations:
1. `btn-icon` for the "flat" buttons that render icons and are gray by default and a brand color on hover.
2. `btn-cancel` and `btn-save` which are currently used in our modal designs.

I've also update the modal in the `TagInput` to match the modal for `OwnerEditor`.