### PR TITLE
Add breadcrumbs + fix to tableData state management

### DIFF
--- a/amundsen_application/static/js/components/NotFoundPage/index.tsx
+++ b/amundsen_application/static/js/components/NotFoundPage/index.tsx
@@ -4,11 +4,13 @@ import * as DocumentTitle from 'react-document-title';
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
 
+import Breadcrumb from "../common/Breadcrumb";
 
 const NotFoundPage: React.SFC<any> = () => {
   return (
     <DocumentTitle title="404 Page Not Found - Amundsen">
-      <div className="not-found-page">
+      <div className="container not-found-page">
+        <Breadcrumb path='/' text='Home'/>
         <h1>404 Page Not Found</h1>
         <span className="glyphicon glyphicon-exclamation-sign" />
       </div>

--- a/amundsen_application/static/js/components/NotFoundPage/styles.scss
+++ b/amundsen_application/static/js/components/NotFoundPage/styles.scss
@@ -1,9 +1,14 @@
 @import 'variables';
 
 .not-found-page {
-  width: 70%;
-  margin: 64px auto 48px;
-  text-align: center;
+  h1 {
+    text-align: center;
+  }
+
+  span  {
+    text-align: center;
+    width: 100%;
+  }
 }
 
 .glyphicon.glyphicon-exclamation-sign {

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -88,63 +88,63 @@ class ProfilePage extends React.Component<ProfilePageProps, ProfilePageState> {
     return tabInfo;
   }
 
+  /* TODO: Add support to direct to 404 page for edgecase of someone typing in
+     or pasting in a bad url. This would be consistent with TableDetail page behavior */ 
   render() {
     const user = this.state.user;
     return (
       <DocumentTitle title={ `${user.display_name} - Amundsen Profile` }>
-        <div>
+        <div className="container profile-page">
           <Breadcrumb path='/' text='Search Results'/>
-          <div className="container profile-page">
-            <div className="profile-header">
-                <div className="profile-avatar">
+          <div className="profile-header">
+              <div className="profile-avatar">
+                {
+                  // default Avatar looks a bit jarring -- intentionally not rendering if no display_name
+                  user.display_name && user.display_name.length > 0 &&
+                  <Avatar name={user.display_name} size={74} round={true} />
+                }
+              </div>
+              <div className="profile-details">
+                <div className="profile-title">
+                  <h1>{ user.display_name }</h1>
                   {
-                    // default Avatar looks a bit jarring -- intentionally not rendering if no display_name
-                    user.display_name && user.display_name.length > 0 &&
-                    <Avatar name={user.display_name} size={74} round={true} />
+                    (user.is_active === false) &&
+                    <Flag caseType="sentenceCase" labelStyle="label-danger" text="Alumni"/>
                   }
                 </div>
-                <div className="profile-details">
-                  <div className="profile-title">
-                    <h1>{ user.display_name }</h1>
-                    {
-                      (user.is_active === false) &&
-                      <Flag caseType="sentenceCase" labelStyle="label-danger" text="Alumni"/>
-                    }
-                  </div>
-                  <text>{ `${user.role_name} on ${user.team_name}` }</text>
-                  <text>{ `Manager: ${user.manager_name}` }</text>
-                  <div className="profile-icons">
-                    {
-                      user.is_active &&
-                      <a href={user.slack_url} className='btn btn-flat-icon' target='_blank'>
-                        <img className='icon icon-slack'/>
-                        <span>Slack</span>
-                      </a>
-                    }
-                    {
-                      user.is_active &&
-                      <a href={`mailto:${user.email}`} className='btn btn-flat-icon' target='_blank'>
-                        <img className='icon icon-mail'/>
-                        <span>{ user.email }</span>
-                      </a>
-                    }
-                    {
-                      user.is_active &&
-                      <a href={user.profile_url} className='btn btn-flat-icon' target='_blank'>
-                        <img className='icon icon-users'/>
-                        <span>Employee Profile</span>
-                      </a>
-                    }
-                    <a href={`https://github.com/${user.github_name}`} className='btn btn-flat-icon' target='_blank'>
-                      <img className='icon icon-github'/>
-                      <span>Github</span>
+                <text>{ `${user.role_name} on ${user.team_name}` }</text>
+                <text>{ `Manager: ${user.manager_name}` }</text>
+                <div className="profile-icons">
+                  {
+                    user.is_active &&
+                    <a href={user.slack_url} className='btn btn-flat-icon' target='_blank'>
+                      <img className='icon icon-slack'/>
+                      <span>Slack</span>
                     </a>
-                  </div>
+                  }
+                  {
+                    user.is_active &&
+                    <a href={`mailto:${user.email}`} className='btn btn-flat-icon' target='_blank'>
+                      <img className='icon icon-mail'/>
+                      <span>{ user.email }</span>
+                    </a>
+                  }
+                  {
+                    user.is_active &&
+                    <a href={user.profile_url} className='btn btn-flat-icon' target='_blank'>
+                      <img className='icon icon-users'/>
+                      <span>Employee Profile</span>
+                    </a>
+                  }
+                  <a href={`https://github.com/${user.github_name}`} className='btn btn-flat-icon' target='_blank'>
+                    <img className='icon icon-github'/>
+                    <span>Github</span>
+                  </a>
                 </div>
-            </div>
-            <div className="profile-tabs">
-              <Tabs tabs={ this.generateTabInfo() } defaultTab='frequentUses_tab' />
-            </div>
+              </div>
+          </div>
+          <div className="profile-tabs">
+            <Tabs tabs={ this.generateTabInfo() } defaultTab='frequentUses_tab' />
           </div>
         </div>
       </DocumentTitle>

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -12,6 +12,7 @@ import TagInput from '../../containers/TagInput';
 
 import AppConfig from '../../../config/config';
 import AvatarLabel from '../common/AvatarLabel';
+import Breadcrumb from "../common/Breadcrumb";
 import DetailList from './DetailList';
 import EntityCard from '../common/EntityCard';
 import LoadingSpinner from '../common/LoadingSpinner';
@@ -296,13 +297,15 @@ class TableDetail extends React.Component<TableDetailProps & RouteComponentProps
       this.props.history.push('/404');
     } else if (this.state.statusCode === 500) {
       innerContent = (
-        <div className="error-label">
+        <div className="container error-label">
+          <Breadcrumb path='/' text='Search Results'/>
           <label className="d-block m-auto">Something went wrong...</label>
         </div>
       )
     } else {
         innerContent = (
           <div className="container table-detail">
+            <Breadcrumb path='/' text='Search Results'/>
             <div className="row">
               <div className="detail-header col-xs-12 col-md-7 col-lg-8">
                   <div className="title">{ `${data.schema}.${data.table_name}` }</div>

--- a/amundsen_application/static/js/components/common/Breadcrumb/index.tsx
+++ b/amundsen_application/static/js/components/common/Breadcrumb/index.tsx
@@ -10,7 +10,7 @@ interface BreadcrumbProps {
 
 const Breadcrumb: React.SFC<BreadcrumbProps> = ({ path, text }) => {
   return (
-    <div className="container amundsen-breadcrumb">
+    <div className="amundsen-breadcrumb">
       <Link to={path}>
         <button className='btn btn-flat-icon'>
           <img className='icon icon-left'/>

--- a/amundsen_application/static/js/components/common/Breadcrumb/styles.scss
+++ b/amundsen_application/static/js/components/common/Breadcrumb/styles.scss
@@ -1,6 +1,8 @@
 @import 'variables';
 
-.container.amundsen-breadcrumb {
-  margin-top: 13px;
-  margin-bottom: -32px;
+.amundsen-breadcrumb {
+  // values chosen for the breadcrumb to sort-of split the difference/center
+  // itself in our 64px top margins.
+  margin-top: -40px;
+  margin-bottom: 21px;
 }

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -129,10 +129,20 @@ export default function reducer(state: TableMetadataReducerState = initialState,
         ...state,
         isLoading: true,
         preview: initialPreviewState,
+        tableData: initialTableDataState,
         tableOwners: tableOwnersReducer(state.tableOwners, action),
         tableTags: tableTagsReducer(state.tableTags, action),
       };
     case GetTableData.FAILURE:
+      return {
+        ...state,
+        isLoading: false,
+        preview: initialPreviewState,
+        statusCode: action.payload.statusCode,
+        tableData: initialTableDataState,
+        tableOwners: tableOwnersReducer(state.tableOwners, action),
+        tableTags: tableTagsReducer(state.tableTags, action),
+      };
     case GetTableData.SUCCESS:
       return {
         ...state,
@@ -148,12 +158,13 @@ export default function reducer(state: TableMetadataReducerState = initialState,
     case GetColumnDescription.FAILURE:
     case GetColumnDescription.SUCCESS:
       return { ...state, tableData: action.payload };
-    case GetLastIndexed.SUCCESS:
-        return { ...state, lastIndexed: action.payload };
     case GetLastIndexed.FAILURE:
-        return { ...state, lastIndexed: null };
-    case GetPreviewData.SUCCESS:
+      return { ...state, lastIndexed: null };
+    case GetLastIndexed.SUCCESS:
+      return { ...state, lastIndexed: action.payload };
     case GetPreviewData.FAILURE:
+      return { ...state, preview: initialPreviewState };
+    case GetPreviewData.SUCCESS:
       return { ...state, preview: action.payload };
     case UpdateTableOwner.ACTION:
     case UpdateTableOwner.FAILURE:

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -24,10 +24,10 @@ import {
 // getTableData
 export function* getTableDataWorker(action: GetTableDataRequest): SagaIterator {
   try {
-    const { data, owners, tags } = yield call(metadataGetTableData, action);
-    yield put({ type: GetTableData.SUCCESS, payload: { data, owners, tags } });
+    const { data, owners, statusCode, tags } = yield call(metadataGetTableData, action);
+    yield put({ type: GetTableData.SUCCESS, payload: { data, owners, statusCode, tags } });
   } catch (e) {
-    yield put({ type: GetTableData.FAILURE, payload: { data: {}, owners: [], tags: [] } });
+    yield put({ type: GetTableData.FAILURE, payload: { data: {}, owners: [], statusCode: 500, tags: [] } });
   }
 }
 


### PR DESCRIPTION
1. Update the `Breadcrumb` positioning styles.
2. Added the `Breadcrumb` to `TableDetail` and `NotFoundPage`. `NotFoundPage` breadcrumb says "Home". 
3. Found a minor bug in `ducks`. I needed to pass back the `statusCode` in the `getTableDataWorker` and I also updated some failure cases to return initial pieces of state. I considered putting this in a separate PR in master, but this particular bug only gets revealed when someone types in a bad table detail page url and instead of getting the `NotFoundPage` they will just get a blank page in master. Let me know if there are any strong feelings about the changes in `ducks` going into master instead.