### PR TITLE
Update setup.py script to fix installation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def build_js() -> None:
         logging.error('npm must be available')
 
     try:
-        subprocess.check_call(['npm install --only=prod'], cwd=PACKAGE_DIR, shell=True)
+        subprocess.check_call(['npm install'], cwd=PACKAGE_DIR, shell=True)
         subprocess.check_call(['npm run build'], cwd=PACKAGE_DIR, shell=True)
     except Exception as e:
         logging.warn('Installation of npm dependencies failed')
@@ -34,7 +34,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 
 setup(


### PR DESCRIPTION
I encountered the same issue mentioned by @verdan  in https://github.com/lyft/amundsenfrontendlibrary/pull/82 with a fresh checkout of the repo. The issue seems to be related to using `npm install  --only==prod`.

I don't have much context as @danwom and @ttannis  on this flag. My understanding is to save the build size to reduce page load time? But I don't think page load time is really an issue with the tool.

Per https://github.com/heartsucker/node-deb/issues/15 , it will skip installing those devDependencies listed in package.json.

By removing the `--only==prod`, the `python setup.py install` command works at my local setup.