### PR TITLE
Update neo4j docker entry to include the network info

### DIFF
--- a/docker-amundsen.yml
+++ b/docker-amundsen.yml
@@ -15,6 +15,8 @@ services:
           - 7687:7687
       volumes:
           - ./example/docker/neo4j/conf:/conf
+      networks:
+        - amundsennet
   elasticsearch:
       image: elasticsearch:6.7.0
       container_name: es_amundsen


### PR DESCRIPTION
As pointed out by @amweiss, the network info is removed from neo4j container in https://github.com/lyft/amundsenfrontendlibrary/pull/91. We should add it back to make the neo4j container accessible by other container(metadata).