### PR TITLE
Fix build commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     install:
     - npm install
     script:
+    - npm run lint
     - npm run build
     - npm run test
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ matrix:
     install:
     - npm install
     script:
-    - npm run lint
+    - npm run eslint
+    - npm run tslint
     - npm run build
     - npm run test
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ matrix:
     install:
     - npm install
     script:
-    - npm run eslint
-    - npm run tslint
+    - npm run lint
     - npm run build
     - npm run test
 deploy:

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -58,7 +58,7 @@ const initialState: SearchReducerState = {
 };
 
 export default function reducer(state: SearchReducerState = initialState, action: SearchReducerAction): SearchReducerState {
-  let newState = action.payload;
+  const newState = action.payload;
   switch (action.type) {
     // SearchAll will reset all resources with search results or the initial state
     case SearchAll.SUCCESS:

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -58,7 +58,7 @@ const initialState: SearchReducerState = {
 };
 
 export default function reducer(state: SearchReducerState = initialState, action: SearchReducerAction): SearchReducerState {
-  const newState = action.payload;
+  let newState = action.payload;
   switch (action.type) {
     // SearchAll will reset all resources with search results or the initial state
     case SearchAll.SUCCESS:

--- a/amundsen_application/static/package.json
+++ b/amundsen_application/static/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "npm run lint && TS_NODE_PROJECT='tsconfig-for-webpack.json' webpack -p --progress --config webpack.prod.ts",
+    "build": "TS_NODE_PROJECT='tsconfig-for-webpack.json' webpack -p --progress --config webpack.prod.ts",
     "dev-build": "TS_NODE_PROJECT='tsconfig-for-webpack.json' webpack -d --progress --config webpack.dev.ts",
     "test": "jest --coverage --collectCoverageFrom=js/**/*.{js,jsx,ts,tsx}",
     "watch": "TS_NODE_PROJECT='tsconfig-for-webpack.json' webpack -d --progress --config webpack.dev.ts --watch",

--- a/amundsen_application/static/package.json
+++ b/amundsen_application/static/package.json
@@ -14,8 +14,8 @@
     "eslint-fix": "eslint --fix --ignore-path=.eslintignore --ext .js,.jsx .",
     "test:watch": "jest --watch",
     "tsc": "tsc",
-    "tslint": "tslint --project . --force",
-    "tslint-fix": "tslint --fix --project . --force"
+    "tslint": "tslint --project .",
+    "tslint-fix": "tslint --fix --project ."
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR fixes a problem that became apparent by https://github.com/lyft/amundsenfrontendlibrary/issues/84, the Travis build was not failing on lint errors. This was because the `tslint` commands were inappropriately using `--force`, which would cause the script to exit without error even if there were lint issues.

**Summary of Changes**
1. Fixed the `tslint` commands to fail if there are errors.
2. Configured `npm run lint` to run as a separate script.