### PR TITLE
Change '.search-error' color to text-medium

### DIFF
--- a/amundsen_application/static/css/_variables-default.scss
+++ b/amundsen_application/static/css/_variables-default.scss
@@ -24,7 +24,7 @@ $brand-color-5: #28409f !default;
 $gray-base:     #000 !default;
 $gray-darker:   lighten($gray-base, 10%) !default; // #1a1a1a
 $gray-dark:     lighten($gray-base, 20%) !default; // #333
-$gray:          lighten($gray-base, 35%) !default; // ##595959
+$gray:          lighten($gray-base, 35%) !default; // #595959
 $gray-light:    lighten($gray-base, 55%) !default; // #8c8c8c
 $gray-lighter:  lighten($gray-base, 75%) !default; // #bfbfbf
 $gray-lightest: lighten($gray-base, 95%) !default; // #f2f2f2

--- a/amundsen_application/static/js/components/SearchPage/styles.scss
+++ b/amundsen_application/static/js/components/SearchPage/styles.scss
@@ -45,7 +45,7 @@
   }
 
   .search-error {
-    color: $gray-lighter;
+    color: $text-medium;
     text-align: center;
   }
 


### PR DESCRIPTION
This PR updates the style of the `.search-error` text to be more readable, using a color value that meets contrast guidelines for text.

**Before**
![image](https://user-images.githubusercontent.com/1790900/56622731-1f171280-65e6-11e9-947b-002a6d302101.png)

**After**
![image](https://user-images.githubusercontent.com/1790900/56622780-4372ef00-65e6-11e9-883e-f57322c3716b.png)
