### PR TITLE
Fix navbar and footer state bugs

### DIFF
--- a/amundsen_application/static/js/components/Footer/index.tsx
+++ b/amundsen_application/static/js/components/Footer/index.tsx
@@ -19,17 +19,9 @@ interface DispatchFromProps {
 
 export type FooterProps = StateFromProps & DispatchFromProps;
 
-interface FooterState {
-  lastIndexed: number;
-}
-
-export class Footer extends React.Component<FooterProps, FooterState> {
+export class Footer extends React.Component<FooterProps> {
   constructor(props) {
     super(props);
-
-    this.state = {
-      lastIndexed: this.props.lastIndexed,
-    };
   }
 
   componentDidMount() {
@@ -38,12 +30,12 @@ export class Footer extends React.Component<FooterProps, FooterState> {
 
   generateDateTimeString = () => {
     // 'moment.local' will utilize the client's local timezone.
-    return moment.unix(this.state.lastIndexed).local().format('MMMM Do YYYY [at] h:mm:ss a');
-  }
+    return moment.unix(this.props.lastIndexed).local().format('MMMM Do YYYY [at] h:mm:ss a');
+  };
 
   render() {
     let content;
-    if (this.state.lastIndexed !== null) {
+    if (this.props.lastIndexed !== null) {
       content = <div>{`Amundsen was last indexed on ${this.generateDateTimeString()}`}</div>;
     }
     return (

--- a/amundsen_application/static/js/components/NavBar/index.tsx
+++ b/amundsen_application/static/js/components/NavBar/index.tsx
@@ -24,12 +24,7 @@ interface DispatchFromProps {
 
 export type NavBarProps = StateFromProps & DispatchFromProps;
 
-// State
-interface NavBarState {
-  loggedInUser: LoggedInUser;
-}
-
-export class NavBar extends React.Component<NavBarProps, NavBarState> {
+export class NavBar extends React.Component<NavBarProps> {
   constructor(props) {
     super(props);
   }

--- a/amundsen_application/static/js/components/NavBar/index.tsx
+++ b/amundsen_application/static/js/components/NavBar/index.tsx
@@ -32,10 +32,6 @@ interface NavBarState {
 export class NavBar extends React.Component<NavBarProps, NavBarState> {
   constructor(props) {
     super(props);
-
-    this.state = {
-      loggedInUser: this.props.loggedInUser,
-    };
   }
 
   componentDidMount() {
@@ -69,9 +65,9 @@ export class NavBar extends React.Component<NavBarProps, NavBarState> {
               {this.generateNavLinks(AppConfig.navLinks)}
               {
                 // TODO PEOPLE - Add link to user profile
-                this.state.loggedInUser &&
+                this.props.loggedInUser &&
                 <div id="nav-bar-avatar">
-                  <Avatar name={this.state.loggedInUser.display_name} size={32} round={true} />
+                  <Avatar name={this.props.loggedInUser.display_name} size={32} round={true} />
                 </div>
               }
             </div>


### PR DESCRIPTION
The navbar and footer components were incorrectly referencing `state` for values that only existed in `props`.