### PR TITLE
Fix console warnings thrown in unit tests

### DIFF
--- a/amundsen_application/static/js/components/NavBar/index.tsx
+++ b/amundsen_application/static/js/components/NavBar/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 import { Link, NavLink, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -38,6 +38,10 @@ export class ProfilePage extends React.Component<ProfilePageProps> {
   componentDidMount() {
     this.props.getUserById(this.userId);
   }
+
+  getUserId = () => {
+    return this.userId;
+  };
 
   // TODO: consider moving logic for empty content into Tab component
   createEmptyTabMessage = (message: string) => {

--- a/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as DocumentTitle from 'react-document-title';
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 
 import { shallow } from 'enzyme';
 
@@ -12,196 +12,232 @@ import { ProfilePage, ProfilePageProps, mapDispatchToProps, mapStateToProps } fr
 import globalState from 'fixtures/globalState';
 
 describe('ProfilePage', () => {
-    let props: ProfilePageProps;
-    let subject;
+  const setup = (propOverrides?: Partial<ProfilePageProps>) => {
+    const props: ProfilePageProps = {
+      user:  {
+        user_id: 'test0',
+        display_name: 'Test User',
+        email: 'test@test.com',
+        github_name: 'githubName',
+        is_active: true,
+        manager_name: 'Test Manager',
+        profile_url: 'www.test.com',
+        role_name: 'Tester',
+        slack_url: 'www.slack.com',
+        team_name: 'QA',
+      },
+      getUserById: jest.fn(),
+      ...propOverrides
+    };
+    // @ts-ignore : complains about match
+    const wrapper = shallow<ProfilePage>(<ProfilePage {...props} match={{params: {userId: 'test0'}}}/>);
+    return { props, wrapper };
+  };
 
-    beforeEach(() => {
-        props = {
-          user:  {
-            user_id: 'test0',
-            display_name: 'Test User',
-            email: 'test@test.com',
-            github_name: 'githubName',
-            is_active: true,
-            manager_name: 'Test Manager',
-            profile_url: 'www.test.com',
-            role_name: 'Tester',
-            slack_url: 'www.slack.com',
-            team_name: 'QA',
-          },
-          getUserById: jest.fn(),
-        };
-        // @ts-ignore : complains about match
-        subject = shallow(<ProfilePage {...props} match={{params: {userId: 'test0'}}}/>);
+  describe('constructor', () => {
+    let props;
+    let wrapper;
+    beforeAll(() => {
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
     });
 
-    describe('constructor', () => {
-        it('sets the userId if it exists on match.params', () => {
-            expect(subject.instance().userId).toEqual('test0');
-        });
-
-        it('sets the userId as empty string if no match.params.userId', () => {
-            // @ts-ignore : complains about match
-            subject = shallow(<ProfilePage {...props} match={{params: {}}}/>);
-            expect(subject.instance().userId).toEqual('');
-        });
+    it('sets the userId if it exists on match.params', () => {
+      expect(wrapper.instance().getUserId()).toEqual('test0');
     });
 
-    describe('componentDidMount', () => {
-        it('calls props.getUserById', () => {
-            expect(props.getUserById).toHaveBeenCalled();
-        });
+    it('sets the userId as empty string if no match.params.userId', () => {
+      // @ts-ignore : complains about match
+      const wrapper = shallow<ProfilePage>(<ProfilePage {...props} match={{params: {}}}/>);
+      expect(wrapper.instance().getUserId()).toEqual('');
+    });
+  });
+
+  describe('componentDidMount', () => {
+    it('calls props.getUserById', () => {
+      const { props, wrapper } = setup();
+      expect(props.getUserById).toHaveBeenCalled();
+    });
+  });
+
+  describe('createEmptyTabMessage', () => {
+    let content;
+    beforeAll(() => {
+      const { props, wrapper } = setup();
+      content = wrapper.instance().createEmptyTabMessage('Empty message');
     });
 
-    describe('createEmptyTabMessage', () => {
-        let content;
-        beforeEach(() => {
-            content = subject.instance().createEmptyTabMessage('Empty message');
-        });
-        it('creates div w/ correct class', () => {
-            expect(shallow(content).find('div').props().className).toEqual('empty-tab-message');
-        });
-
-        it('creates text with given message', () => {
-            expect(shallow(content).find('text').text()).toEqual('Empty message');
-        });
+    it('creates div w/ correct class', () => {
+      expect(shallow(content).find('div').props().className).toEqual('empty-tab-message');
     });
 
-    /* TODO: Implement proper test when the real logic for this component is written */
-    describe('generateTabInfo', () => {
-        let tabInfoArray;
-        beforeEach(() => {
-            tabInfoArray = subject.instance().generateTabInfo();
-        });
-        it('has a passing test so that it does not throw an error', () => {
-            expect(true).toEqual(true);
-        });
+    it('creates text with given message', () => {
+      expect(shallow(content).find('text').text()).toEqual('Empty message');
+    });
+  });
+
+  /* TODO: Implement proper test when the real logic for this component is written */
+  describe('generateTabInfo', () => {
+    let tabInfoArray;
+    beforeAll(() => {
+      const { props, wrapper } = setup();
+      tabInfoArray = wrapper.instance().generateTabInfo();
     });
 
-    describe('render', () => {
-        it('renders DocumentTitle w/ correct title', () => {
-            expect(subject.find(DocumentTitle).props().title).toEqual(`${props.user.display_name} - Amundsen Profile`);
-        });
-
-        it('renders Breadcrumb with correct props', () => {
-            expect(subject.find(Breadcrumb).props()).toMatchObject({
-              path: '/',
-              text: 'Search Results',
-            });
-        });
-
-        it('renders Avatar for user.display_name', () => {
-            /* Note: subject.find(Avatar) does not work - workaround is to directly check the content */
-            const expectedContent = <Avatar name={props.user.display_name} size={74} round={true} />;
-            expect(subject.find('#profile-avatar').props().children).toEqual(expectedContent);
-        });
-
-        it('does not render Avatar if user.display_name is empty string', () => {
-            props.user.display_name = '';
-            subject.setProps(props);
-            expect(subject.find('#profile-avatar').children().exists()).toBeFalsy();
-        });
-
-        it('renders header with display_name', () => {
-            expect(subject.find('#profile-title').find('h1').text()).toEqual(props.user.display_name);
-        });
-
-        it('renders Flag with correct props if user not active', () => {
-            props.user.is_active = false;
-            subject.setProps(props);
-            expect(subject.find('#profile-title').find(Flag).props()).toMatchObject({
-              caseType: 'sentenceCase',
-              labelStyle: 'label-danger',
-              text: 'Alumni',
-            });
-        });
-
-        it('renders user role', () => {
-            expect(subject.find('#user-role').text()).toEqual('Tester on QA');
-        });
-
-        it('renders user manager', () => {
-            expect(subject.find('#user-manager').text()).toEqual('Manager: Test Manager');
-        });
-
-        it('renders user manager', () => {
-            expect(subject.find('#user-manager').text()).toEqual('Manager: Test Manager');
-        });
-
-        it('renders slack link with correct href if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#slack-link').props().href).toEqual('www.slack.com');
-        });
-
-        it('renders slack link with correct text if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#slack-link').find('span').text()).toEqual('Slack');
-        });
-
-        it('renders email link with correct href if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#email-link').props().href).toEqual('mailto:test@test.com');
-        });
-
-        it('renders email link with correct text if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#email-link').find('span').text()).toEqual('test@test.com');
-        });
-
-        it('renders profile link with correct href if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#profile-link').props().href).toEqual('www.test.com');
-        });
-
-        it('renders profile link with correct text if user.is_active', () => {
-            props.user.is_active = true;
-            subject.setProps(props);
-            expect(subject.find('#profile-link').find('span').text()).toEqual('Employee Profile');
-        });
-
-        it('renders github link with correct href', () => {
-            expect(subject.find('#github-link').props().href).toEqual('https://github.com/githubName');
-        });
-
-        it('renders github link with correct text', () => {
-            expect(subject.find('#github-link').find('span').text()).toEqual('Github');
-        });
-
-        it('renders Tabs w/ correct props', () => {
-            expect(subject.find('#profile-tabs').find(Tabs).props()).toMatchObject({
-              tabs: subject.instance().generateTabInfo(),
-              defaultTab: 'frequentUses_tab',
-            });
-        });
+    it('has a passing test so that it does not throw an error', () => {
+      expect(true).toEqual(true);
     });
+  });
+
+  describe('render', () => {
+    let props;
+    let wrapper;
+    beforeAll(() => {
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
+    });
+
+    it('renders DocumentTitle w/ correct title', () => {
+      expect(wrapper.find(DocumentTitle).props().title).toEqual(`${props.user.display_name} - Amundsen Profile`);
+    });
+
+    it('renders Breadcrumb with correct props', () => {
+      expect(wrapper.find(Breadcrumb).props()).toMatchObject({
+        path: '/',
+        text: 'Search Results',
+      });
+    });
+
+    it('renders Avatar for user.display_name', () => {
+      expect(wrapper.find(Avatar).props()).toMatchObject({
+        name: props.user.display_name,
+        size: 74,
+        round: true,
+      });
+    });
+
+    it('does not render Avatar if user.display_name is empty string', () => {
+      const wrapper = setup({
+        user: {
+          user_id: 'test0',
+          display_name: '',
+          email: 'test@test.com',
+          github_name: 'githubName',
+          is_active: true,
+          manager_name: 'Test Manager',
+          profile_url: 'www.test.com',
+          role_name: 'Tester',
+          slack_url: 'www.slack.com',
+          team_name: 'QA',
+        }
+      }).wrapper;
+      expect(wrapper.find('#profile-avatar').children().exists()).toBeFalsy();
+    });
+
+    it('renders header with display_name', () => {
+      expect(wrapper.find('#profile-title').find('h1').text()).toEqual(props.user.display_name);
+    });
+
+    it('renders Flag with correct props if user not active', () => {
+      const wrapper = setup({
+        user: {
+          user_id: 'test0',
+          display_name: '',
+          email: 'test@test.com',
+          github_name: 'githubName',
+          is_active: false,
+          manager_name: 'Test Manager',
+          profile_url: 'www.test.com',
+          role_name: 'Tester',
+          slack_url: 'www.slack.com',
+          team_name: 'QA',
+        }
+      }).wrapper;
+      expect(wrapper.find('#profile-title').find(Flag).props()).toMatchObject({
+        caseType: 'sentenceCase',
+        labelStyle: 'label-danger',
+        text: 'Alumni',
+      });
+    });
+
+    it('renders user role', () => {
+      expect(wrapper.find('#user-role').text()).toEqual('Tester on QA');
+    });
+
+    it('renders user manager', () => {
+      expect(wrapper.find('#user-manager').text()).toEqual('Manager: Test Manager');
+    });
+
+    it('renders user manager', () => {
+      expect(wrapper.find('#user-manager').text()).toEqual('Manager: Test Manager');
+    });
+
+    it('renders github link with correct href', () => {
+      expect(wrapper.find('#github-link').props().href).toEqual('https://github.com/githubName');
+    });
+
+    it('renders github link with correct text', () => {
+      expect(wrapper.find('#github-link').find('span').text()).toEqual('Github');
+    });
+
+    it('renders Tabs w/ correct props', () => {
+      expect(wrapper.find('#profile-tabs').find(Tabs).props()).toMatchObject({
+        tabs: wrapper.instance().generateTabInfo(),
+        defaultTab: 'frequentUses_tab',
+      });
+    });
+
+    describe('if user.is_active', () => {
+      it('renders slack link with correct href', () => {
+        expect(wrapper.find('#slack-link').props().href).toEqual('www.slack.com');
+      });
+
+      it('renders slack link with correct text', () => {
+        expect(wrapper.find('#slack-link').find('span').text()).toEqual('Slack');
+      });
+
+      it('renders email link with correct href', () => {
+        expect(wrapper.find('#email-link').props().href).toEqual('mailto:test@test.com');
+      });
+
+      it('renders email link with correct text', () => {
+        expect(wrapper.find('#email-link').find('span').text()).toEqual('test@test.com');
+      });
+
+      it('renders profile link with correct href', () => {
+        expect(wrapper.find('#profile-link').props().href).toEqual('www.test.com');
+      });
+
+      it('renders profile link with correct text', () => {
+        expect(wrapper.find('#profile-link').find('span').text()).toEqual('Employee Profile');
+      });
+    });
+  });
 });
 
 describe('mapDispatchToProps', () => {
-    let dispatch;
-    let result;
+  let dispatch;
+  let result;
 
-    beforeEach(() => {
-        dispatch = jest.fn(() => Promise.resolve());
-        result = mapDispatchToProps(dispatch);
-    });
+  beforeEach(() => {
+    dispatch = jest.fn(() => Promise.resolve());
+    result = mapDispatchToProps(dispatch);
+  });
 
-    it('sets getUserById on the props', () => {
-        expect(result.getUserById).toBeInstanceOf(Function);
-    });
+  it('sets getUserById on the props', () => {
+    expect(result.getUserById).toBeInstanceOf(Function);
+  });
 });
 
 describe('mapStateToProps', () => {
-    let result;
-    beforeEach(() => {
-        result = mapStateToProps(globalState);
-    });
+  let result;
+  beforeEach(() => {
+    result = mapStateToProps(globalState);
+  });
 
-    it('sets user on the props', () => {
-        expect(result.user).toEqual(globalState.user.profileUser);
-    });
+  it('sets user on the props', () => {
+    expect(result.user).toEqual(globalState.user.profileUser);
+  });
 });

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import * as Avatar from 'react-avatar';
 import * as DocumentTitle from 'react-document-title';
 import * as qs from 'simple-query-string';
 
@@ -25,7 +26,6 @@ import TableDescEditableText from './TableDescEditableText';
 import WatermarkLabel from "./WatermarkLabel";
 import { logClick } from 'ducks/utilMethods';
 
-import Avatar from 'react-avatar';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { RouteComponentProps } from 'react-router';
 

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';

--- a/amundsen_application/static/js/components/common/AvatarLabel/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/tests/index.spec.tsx
@@ -1,31 +1,41 @@
 import * as React from 'react';
+import * as Avatar from 'react-avatar';
 
 import { shallow } from 'enzyme';
 
-import { Avatar } from 'react-avatar';
 import AvatarLabel, { AvatarLabelProps } from '../';
 
 describe('AvatarLabel', () => {
+  const setup = (propOverrides?: Partial<AvatarLabelProps>) => {
+    const props: AvatarLabelProps = {
+      ...propOverrides
+    };
+    const wrapper = shallow(<AvatarLabel {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
     let props: AvatarLabelProps;
-    let subject;
-
-    beforeEach(() => {
-        props = {
-          label: 'testLabel',
-          src: 'testSrc',
-        };
-        subject = shallow(<AvatarLabel {...props} />);
+    let wrapper;
+    beforeAll(() => {
+      const setupResult = setup({
+        label: 'testLabel',
+        src: 'testSrc',
+      });
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
+    });
+    it('renders Avatar with correct props', () => {
+      expect(wrapper.find(Avatar).props()).toMatchObject({
+        name: props.label,
+        src: props.src,
+        size: 24,
+        round: true,
+      });
     });
 
-    describe('render', () => {
-        it('renders Avatar with correct props', () => {
-            /* Note: subject.find(Avatar) does not work - workaround is to directly check the content */
-            const expectedContent = <Avatar name={props.label} src={props.src} size={24} round={true} />;
-            expect(subject.find('#component-avatar').props().children).toEqual(expectedContent);
-        });
-
-        it('renders label with correct text', () => {
-            expect(subject.find('#component-label').text()).toEqual(props.label);
-        });
+    it('renders label with correct text', () => {
+      expect(wrapper.find('label').text()).toEqual(props.label);
     });
+  });
 });

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
@@ -38,12 +38,6 @@ class TableListItem extends React.Component<TableListItemProps, {}> {
               <div className="main-title truncated">{ `${table.schema_name}.${table.name}`}</div>
               <div className="description truncated">{ table.description }</div>
             </div>
-            {/*<div className={ hasLastUpdated? "hidden-xs col-sm-3 col-md-4" : "hidden-xs col-sm-6"}>*/}
-              {/*<div className="secondary-title">Frequent Users</div>*/}
-              {/*<div className="description truncated">*/}
-                {/*<label> </label>*/}
-              {/*</div>*/}
-            {/*</div>*/}
             {
               hasLastUpdated &&
               <div className="hidden-xs col-sm-3 col-md-2">

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -2,73 +2,93 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import Avatar from 'react-avatar';
 import { Link } from 'react-router-dom';
 
 import TableListItem, { TableListItemProps } from '../';
 import { ResourceType } from '../../types';
 
 describe('TableListItem', () => {
+  const setup = (propOverrides?: Partial<TableListItemProps>) => {
+    const props: TableListItemProps = {
+      logging: { source: 'src', index: 0 },
+      table: {
+        type: ResourceType.table,
+        cluster: '',
+        database: '',
+        description: 'I am the description',
+        key: '',
+        last_updated_epoch: 1553829681,
+        name: 'tableName',
+        schema_name: 'tableSchema',
+      },
+      ...propOverrides
+    };
+    const wrapper = shallow<TableListItem>(<TableListItem {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
     let props: TableListItemProps;
-    let subject;
+    let wrapper;
 
-    beforeEach(() => {
-        props = {
-          logging: { source: 'src', index: 0 },
-          table: {
-            type: ResourceType.table,
-            cluster: '',
-            database: '',
-            description: 'I am the description',
-            key: '',
-            last_updated_epoch: null,
-            name: 'tableName',
-            schema_name: 'tableSchema',
-          },
-        }
-        subject = shallow(<TableListItem {...props} />);
+    beforeAll(() => {
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
+    });
+    it('renders item as Link', () => {
+      expect(wrapper.find(Link).exists()).toBeTruthy();
     });
 
-    describe('render', () => {
-        it('renders item as Link', () => {
-          expect(subject.find(Link).exists()).toBeTruthy();
-        });
-
-        it('renders table name', () => {
-          expect(subject.find('.content').children().at(0).children().at(0).text()).toEqual('tableSchema.tableName');
-        });
-
-        it('renders table description', () => {
-          expect(subject.find('.content').children().at(0).children().at(1).text()).toEqual('I am the description');
-        });
-
-        it('renders secondary title if table has last_updated_epoch ', () => {
-          props.table.last_updated_epoch = 1553829681;
-          subject.setProps(props);
-          expect(subject.find('.content').children().at(1).children().at(0).text()).toEqual('Last Updated');
-        });
-
-        it('renders secondary description w/ getDateLabel value if table has last_updated_epoch ', () => {
-          subject.instance().getDateLabel = jest.fn(() => 'Mar 28, 2019')
-          props.table.last_updated_epoch = 1553829681;
-          subject.setProps(props);
-          expect(subject.find('.content').children().at(1).children().at(1).text()).toEqual('Mar 28, 2019');
-        });
+    it('renders table name', () => {
+      expect(wrapper.find('.content').children().at(0).children().at(0).text()).toEqual('tableSchema.tableName');
     });
 
-    describe('getDateLabel', () => {
-        it('getDateLabel returns correct string', () => {
-          props.table.last_updated_epoch = 1553829681;
-          subject.setProps(props);
-          /* Note: Jest will convert date to UTC, expect to see different strings for an epoch value in the tests vs UI*/
-          expect(subject.instance().getDateLabel()).toEqual('Mar 29, 2019');
-        });
+    it('renders table description', () => {
+      expect(wrapper.find('.content').children().at(0).children().at(1).text()).toEqual('I am the description');
     });
 
-    describe('getLink', () => {
-        it('getLink returns correct string', () => {
-          const { table, logging } = props;
-          expect(subject.instance().getLink()).toEqual(`/table_detail/${table.cluster}/${table.database}/${table.schema_name}/${table.name}?index=${logging.index}&source=${logging.source}`);
-        });
+    describe('if props.table has last_updated_epoch', () => {
+      it('renders Last Update title', () => {
+        expect(wrapper.find('.content').children().at(1).children().at(0).text()).toEqual('Last Updated');
+      });
+
+      /*it('renders getDateLabel value', () => {
+        wrapper.update();
+        expect(wrapper.find('.content').children().at(1).children().at(1).text()).toEqual('Mar 29, 2019');
+      });*/
     });
+
+    describe('if props.table does not have last_updated_epoch', () => {
+      it('does not render Last Updated section', () => {
+        const { props, wrapper } = setup({ table: {
+          type: ResourceType.table,
+          cluster: '',
+          database: '',
+          description: 'I am the description',
+          key: '',
+          last_updated_epoch: null,
+          name: 'tableName',
+          schema_name: 'tableSchema',
+        }});
+        expect(wrapper.find('.content').children().at(1).exists()).toBeFalsy();
+      });
+    });
+  });
+
+  /* Note: Jest will convert date to UTC, expect to see different strings for an epoch value in the tests vs UI*/
+  /*describe('getDateLabel', () => {
+    it('getDateLabel returns correct string', () => {
+      const { props, wrapper } = setup();
+      expect(wrapper.instance().getDateLabel()).toEqual('Mar 29, 2019');
+    });
+  });*/
+
+  describe('getLink', () => {
+    it('getLink returns correct string', () => {
+      const { props, wrapper } = setup();
+      const { table, logging } = props;
+      expect(wrapper.instance().getLink()).toEqual(`/table_detail/${table.cluster}/${table.database}/${table.schema_name}/${table.name}?index=${logging.index}&source=${logging.source}`);
+    });
+  });
 });

--- a/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 import { Link } from 'react-router-dom';
 
 import { LoggingParams, UserResource} from '../types';

--- a/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/tests/index.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import Avatar from 'react-avatar';
+import * as Avatar from 'react-avatar';
 import Flag from 'components/common/Flag';
 import { Link } from 'react-router-dom';
 
@@ -10,65 +10,99 @@ import UserListItem, { UserListItemProps } from '../';
 import { ResourceType } from '../../types';
 
 describe('UserListItem', () => {
+  const setup = (propOverrides?: Partial<UserListItemProps>) => {
+    const props: UserListItemProps = {
+      logging: { source: 'src', index: 0 },
+      user: {
+        type: ResourceType.user,
+        active: true,
+        birthday: null,
+        department: 'Department',
+        email: 'test@test.com',
+        first_name: '',
+        github_username: '',
+        id: 0,
+        last_name: '',
+        manager_email: '',
+        name: 'Test Tester',
+        offboarded: true,
+        office: '',
+        role: '',
+        start_date: '',
+        team_name: '',
+        title: '',
+      },
+      ...propOverrides
+    };
+    const wrapper = shallow<UserListItem>(<UserListItem {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
     let props: UserListItemProps;
-    let subject;
+    let wrapper;
 
-    beforeEach(() => {
-        props = {
-          logging: { source: 'src', index: 0 },
-          user: {
-            type: ResourceType.user,
-            active: true,
-            birthday: null,
-            department: 'Department',
-            email: 'test@test.com',
-            first_name: '',
-            github_username: '',
-            id: 0,
-            last_name: '',
-            manager_email: '',
-            name: 'Test Tester',
-            offboarded: true,
-            office: '',
-            role: '',
-            start_date: '',
-            team_name: '',
-            title: '',
-          },
+    beforeAll(() => {
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
+    });
+
+    it('renders item as Link', () => {
+      expect(wrapper.find(Link).exists()).toBeTruthy();
+    });
+
+    it('renders Avatar', () => {
+      expect(wrapper.find(Link).find(Avatar).props()).toMatchObject({
+        name: props.user.name,
+        size: 24,
+        round: true,
+      });
+    });
+
+    it('renders user.name', () => {
+      expect(wrapper.find('.content').children().at(0).children().at(0).children().at(0).text()).toEqual(props.user.name);
+    });
+
+    it('does not render Alumni flag if user is active', () => {
+      expect(wrapper.find('.content').children().at(0).children().at(0).find(Flag).exists()).toBeFalsy();
+    });
+
+    it('renders description', () => {
+      expect(wrapper.find('.content').children().at(0).children().at(1).text()).toEqual(`${props.user.role} on ${props.user.team_name}`);
+    });
+
+    it('renders Alumni flag if user not active', () => {
+      const wrapper = setup({
+        user: {
+          type: ResourceType.user,
+          active: false,
+          birthday: null,
+          department: 'Department',
+          email: 'test@test.com',
+          first_name: '',
+          github_username: '',
+          id: 0,
+          last_name: '',
+          manager_email: '',
+          name: 'Test Tester',
+          offboarded: true,
+          office: '',
+          role: '',
+          start_date: '',
+          team_name: '',
+          title: '',
         }
-        subject = shallow(<UserListItem {...props} />);
+      }).wrapper;
+      expect(wrapper.find('.content').children().at(0).children().at(0).find(Flag).exists()).toBeTruthy();
     });
+  });
 
-    describe('render', () => {
-        it('renders item as Link', () => {
-          expect(subject.find(Link).exists()).toBeTruthy();
-        });
-
-        /* TODO (ttannis): Avatar tests wont pass
-        it('renders Avatar', () => {
-          expect(subject.find(Link).find(Avatar).exists()).toBeTruthy();
-        });*/
-
-        it('renders user.name', () => {
-          expect(subject.find('.content').children().at(0).children().at(0).children().at(0).text()).toEqual(props.user.name);
-        });
-
-        it('renders Alumni flag if user not active', () => {
-          props.user.active = false;
-          subject.setProps(props);
-          expect(subject.find('.content').children().at(0).children().at(0).find(Flag).exists()).toBeTruthy();
-        });
-
-        it('renders description', () => {
-          const { user } = props;
-          expect(subject.find('.content').children().at(0).children().at(1).text()).toEqual(`${user.role} on ${user.team_name}`);
-        });
+  describe('getLink', () => {
+    it('getLink returns correct string', () => {
+      const { props, wrapper } = setup();
+      const { user, logging } = props;
+      expect(wrapper.instance().getLink()).toEqual(`/user/${user.id}/?index=${logging.index}&source=${logging.source}`);
     });
-
-    describe('getLink', () => {
-        it('getLink returns correct string', () => {
-          const { user, logging } = props;
-          expect(subject.instance().getLink()).toEqual(`/user/${user.id}/?index=${logging.index}&source=${logging.source}`);
-        });
-    });
+  });
 });

--- a/amundsen_application/static/package-lock.json
+++ b/amundsen_application/static/package-lock.json
@@ -11743,20 +11743,13 @@
       }
     },
     "react-avatar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-3.6.0.tgz",
-      "integrity": "sha512-4iuXEAHGlwthN+T2vrHdVikQoiX9zbCZCsNMy3Vg0TF5yC+RSAnV2aWe0aGka15ZxGSLlzcZ6MWt4Gt/XXQlVg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-2.5.1.tgz",
+      "integrity": "sha512-bwH5pWY6uxaKZt+IZBfD+SU3Dpy3FaKbmAzrOI4N8SATUPLXOdGaJHWUl6Vl8hHSwWSsoLh/m7xYHdnn0lofZw==",
       "requires": {
-        "core-js": "^2.5.7",
+        "babel-runtime": ">=5.0.0",
         "is-retina": "^1.0.3",
         "md5": "^2.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-        }
       }
     },
     "react-bootstrap": {

--- a/amundsen_application/static/package-lock.json
+++ b/amundsen_application/static/package-lock.json
@@ -11743,13 +11743,20 @@
       }
     },
     "react-avatar": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-2.5.1.tgz",
-      "integrity": "sha1-W76MHQpSWT1GCPs9hinamV7rcJU=",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-3.6.0.tgz",
+      "integrity": "sha512-4iuXEAHGlwthN+T2vrHdVikQoiX9zbCZCsNMy3Vg0TF5yC+RSAnV2aWe0aGka15ZxGSLlzcZ6MWt4Gt/XXQlVg==",
       "requires": {
-        "babel-runtime": ">=5.0.0",
+        "core-js": "^2.5.7",
         "is-retina": "^1.0.3",
         "md5": "^2.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        }
       }
     },
     "react-bootstrap": {

--- a/amundsen_application/static/package.json
+++ b/amundsen_application/static/package.json
@@ -84,7 +84,7 @@
     "jquery": "^3.3.1",
     "moment-timezone": "^0.5.21",
     "react": "^16.3.1",
-    "react-avatar": "^3.6.0",
+    "react-avatar": "^2.5.1",
     "react-bootstrap": "^0.32.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.3.1",

--- a/amundsen_application/static/package.json
+++ b/amundsen_application/static/package.json
@@ -84,7 +84,7 @@
     "jquery": "^3.3.1",
     "moment-timezone": "^0.5.21",
     "react": "^16.3.1",
-    "react-avatar": "^2.5.1",
+    "react-avatar": "^3.6.0",
     "react-bootstrap": "^0.32.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.3.1",


### PR DESCRIPTION
### Summary of Changes

Previously there were console errors getting thrown in our unit tests regarding import errors:
<img src='https://user-images.githubusercontent.com/1790900/57116086-c17e7680-6d07-11e9-83db-bb75aa08a59e.png' width='75%'/>

The way we were importing the 3rd party `Avatar` from the `react-avatar` library was causing this error. The fix was to switch `import Avatar from 'react-avatar'` to `import * as Avatar from 'react-avatar'`.

### Tests
I have updated all test files that use the `Avatar` component, as well as updated these tests to use the new recommended patterns detailed [here](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/recommended_practices.md). 

_Note_: Because of the syntax changes, test files may be easier to review by forgoing the diff and viewing the entire file. 

### Documentation

No documentation is needed as no new APIs have been added.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
