### PR TITLE
Docs: Add logo config example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,3 +13,11 @@ Certain features of the React application import variables from an [AppConfig](h
 ### Custom Fonts & Styles
 Fonts and css variables can be customized by modifying [fonts-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_fonts-custom.scss) and
 [variables-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_variables-custom.scss).
+
+### Examples
+
+#### 1) To add a custom logo you need to do the following:
+
+1. Add your logo to the folder in `amundsen_application/static/images/`
+2. Add the config for `logoPath`. For example Lyft uses the value  `"/static/images/lyft-logo.svg"`
+3. Rebuild/redeploy. The `npm run build` step will rebuild scripts file to reference the new logo image, and the `python3 setup.py install` step will updated deployed files and make the new image available on the server.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,14 +10,12 @@ For more information on how the configuration is being loaded and used, please r
 ### Application Config
 Certain features of the React application import variables from an [AppConfig](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/js/config/config.ts#L5) object. The configuration can be customized by modifying [config-custom.ts](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/js/config/config-custom.ts).
 
-### Custom Fonts & Styles
-Fonts and css variables can be customized by modifying [fonts-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_fonts-custom.scss) and
-[variables-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_variables-custom.scss).
-
-### Examples
-
-#### 1) To add a custom logo you need to do the following:
+#### Example: Add a custom logo
 
 1. Add your logo to the folder in `amundsen_application/static/images/`
 2. Add the config for `logoPath`. For example Lyft uses the value  `"/static/images/lyft-logo.svg"`
 3. Rebuild/redeploy. The `npm run build` step will rebuild scripts file to reference the new logo image, and the `python3 setup.py install` step will updated deployed files and make the new image available on the server.
+
+### Custom Fonts & Styles
+Fonts and css variables can be customized by modifying [fonts-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_fonts-custom.scss) and
+[variables-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_variables-custom.scss).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ Certain features of the React application import variables from an [AppConfig](h
 #### Example: Add a custom logo
 
 1. Add your logo to the folder in `amundsen_application/static/images/`
-2. Add the config for `logoPath`. For example Lyft uses the value  `"/static/images/lyft-logo.svg"`
+2. Set the the `logoPath` key on the `AppConfigCustom` object in [config-custom.ts](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/js/config/config-custom.ts). For example Lyft uses the value `"/static/images/lyft-logo.svg"`
 3. Rebuild/redeploy. The `npm run build` step will rebuild scripts file to reference the new logo image, and the `python3 setup.py install` step will updated deployed files and make the new image available on the server.
 
 ### Custom Fonts & Styles


### PR DESCRIPTION
Verbatim copy of a Slack answer given by @danwom (better give credit where it’s due 🙂)

Having a few specific examples to go from in config docs always give you a good start


