### PR TITLE
Remove unnecessary param in SearchPage setup()

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
@@ -33,7 +33,7 @@ import globalState from 'fixtures/globalState';
 describe('SearchPage', () => {
   const setStateSpy = jest.spyOn(SearchPage.prototype, 'setState');
 
-  const setup = (propOverrides?: Partial<SearchPageProps>, useMount?: boolean) => {
+  const setup = (propOverrides?: Partial<SearchPageProps>) => {
     const props: SearchPageProps = {
       searchTerm: globalState.search.search_term,
       popularTables: globalState.popularTables,


### PR DESCRIPTION
### Summary of Changes

Forgot to remove this param from a previous PR. This parameter isn't being used and don't want the pattern to get propagated if anyone does a copy-paste.

### Tests

No tests need to be updated for this kind of fix.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
