### PR TITLE
Fixes issue where searchbar is not editable on chrome

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchBar/index.tsx
@@ -23,6 +23,7 @@ interface SearchBarState {
   subTextClassName: string;
   searchTerm: string;
   subText: string;
+  modifiedState: boolean;
 }
 
 class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
@@ -39,16 +40,20 @@ class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
       subTextClassName: '',
       searchTerm: this.props.searchTerm,
       subText: this.props.subText,
+      modifiedState: false,
     };
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { searchTerm } = props;
-    return { searchTerm };
+    if (!state.modifiedState) {
+      const { searchTerm } = props;
+      return { searchTerm };
+    }
+    return null;
   }
 
   handleValueChange = (event: React.SyntheticEvent<HTMLInputElement>) : void => {
-    this.setState({ searchTerm: (event.target as HTMLInputElement).value.toLowerCase() });
+    this.setState({ searchTerm: (event.target as HTMLInputElement).value.toLowerCase(), modifiedState: true });
   };
 
   handleValueSubmit = (event: React.FormEvent<HTMLFormElement>) : void => {

--- a/amundsen_application/static/js/components/SearchPage/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchBar/tests/index.spec.tsx
@@ -59,7 +59,8 @@ describe('SearchBar', () => {
       const { props, wrapper } = setup();
       // @ts-ignore: mocked events throw type errors
       wrapper.instance().handleValueChange(valueChangeMockEvent);
-      expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: valueChangeMockEvent.target.value.toLowerCase() });
+      expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: valueChangeMockEvent.target.value.toLowerCase(),
+        modifiedState: true });
     });
   });
 


### PR DESCRIPTION
### Summary of Changes

On Linux Chrome 74.0.3729.131 I was unable to edit anything in the search bar input field. I did some investigation and found that the "render" method in react always calls "getDerivedStateFromProps" before every render.

I inserted some console.log statements to confirm the flow of function calls and noticed  that this was the case. The following page from react states useful things about unconditionally copying state from the props into the value:

https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html

Because of type checking I was unable to add another property to the state that was not already in props. So I opted for a simple searchTerm conditional check. 

Recompiling and rerunning this on my computer gave me the ability to type text in there.

I'm by no means a web let alone a react developer, but this PR should serve as useful input to a discussion to fix this in a better way.

### Tests

* The unit tests still pass
* When the page is loaded without "searchTerm" in the url, the default placeholder is inserted
* When a url is refreshed that has "searchTerm", the text is inserted into the box.

### Checklist

I attempted to run "npm run lint", but that gave me errors:

Tried to lint /data/amundsen/amundsenfrontendlibrary/amundsen_application/static/jest.config.js but found no valid, enabled rules for this file type and file path in the resolved configuration.
Tried to lint /data/amundsen/amundsenfrontendlibrary/amundsen_application/static/coverage/lcov-report/prettify.js but found no valid, enabled rules for this file type and file path in the resolved configuration.
Tried to lint /data/amundsen/amundsenfrontendlibrary/amundsen_application/static/coverage/lcov-report/sorter.js but found no valid, enabled rules for this file type and file path in the resolved configuration.
Tried to lint /data/amundsen/amundsenfrontendlibrary/amundsen_application/static/dist/main.js but found no valid, enabled rules for this file type and file path in the resolved configuration.
Tried to lint /data/amundsen/amundsenfrontendlibrary/amundsen_application/static/dist/vendors.js but found no valid, enabled rules for this file type and file path in the resolved configuration.
