### PR TITLE
Fix error in handling the logged in user response

### DIFF
--- a/amundsen_application/static/js/ducks/user/api/v0.ts
+++ b/amundsen_application/static/js/ducks/user/api/v0.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosResponse, AxiosError } from 'axios';
 
-import { LoggedInUser, UserResponse } from '../types';
+import { LoggedInUserResponse, UserResponse } from '../types';
 
 export function getLoggedInUser() {
   return axios.get(`/api/auth_user`)
-    .then((response: AxiosResponse<LoggedInUser>) => {
-      return response.data;
+    .then((response: AxiosResponse<LoggedInUserResponse>) => {
+      return response.data.user;
     }).catch((error: AxiosError) => {
       return {};
     });

--- a/amundsen_application/static/js/ducks/user/types.ts
+++ b/amundsen_application/static/js/ducks/user/types.ts
@@ -17,6 +17,7 @@ export interface User {
 }
 export type LoggedInUser = User & {};
 
+export type LoggedInUserResponse = { user: LoggedInUser; msg: string; };
 export type UserResponse = { user: User; msg: string; };
 
 /* getLoggedInUser */


### PR DESCRIPTION
### Summary of Changes

In https://github.com/lyft/amundsenfrontendlibrary/pull/90 we changed the payload returned by the `/api/auth_user`. Before #90 the response data was the user object -- now it is an object with a `user` key. We missed updating how we parse the response data before sending the result to the application. 

### Tests

We're working on improving our test coverage, and tests for this part of the application have yet to be scaffolded. We aim to resolve this in the upcoming sprints.

### Documentation

N/A. This section of the application code has no relevant documentation.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
