### PR TITLE
[DPTOOLS-2252] Publish Docker image via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,15 @@ deploy:
     tags: true
     repo: lyft/amundsenfrontendlibrary
     condition: $IS_DEPLOYABLE = true
+deploy:
+  provider: script
+  script: docker login -u amundsendev -p $DOCKER_LOGIN_PASSWORD && make build-push-image
+  on:
+    branch: master
+    tags: true
+    repo: lyft/amundsenfrontendlibrary
+    condition: $IS_DEPLOYABLE = true
+
+env:
+  matrix:
+    secure: jvpvfKHbZYDaLgNh/sNPOd2ZU2v4xhrKnPiIKyiHgATTOo1kk+u7H9wsOTjalFwrUi7LtbVgi7XN81bV5toAK/EUBDsNzS7AHJRPnhCLc+jj56JDGH8QcnSeHp3+fDGPQ2rcJUhFZ1r+9NW6V9WQzviuTqUIKY9p7em/Pop2Z8hth6DZuaOkcmozlwMPRGxOZvglEgpD43dVYQraixPJNk+/D3fa26S8be9DdBqE/Cjxs1ZGHQpMxBQSR753/jmt1oCUfS2Bdrh6+/S7oJf7rHrsMWR8TEt1f6HF1wf+0RZUhmY0rCB7PVchcRxz4QusdabQ564pHizIYZ99jd/PGj2wQwYf5hKOgAOukYbxVS/9HPDQOTy9KAcpLmbwXQ6u+GgTF9ZRzhTPY2cvEiavSgUd8Nf5gSyFtw/JDyc8guhxsYSoe44mZHbxNr3VV043YMrQS/5vAiBASwtoC8lzxD1S391EMFcECmmILLne7+bO0h9aQcq+Weijq2W7d/Ec5MTMpHUMZBAgZO6FM9zpY6bTQhfl8PuQViXOfBVZNZZ7n5Cv7XA0vidQS6oPpYBZaw9PZ5nfoFBt5fcZ3kzk/m5JWFQ/+2Ed5ZG7v+fH7Xz/oStkzP/JP2RDnq/5X8VK1L3t3v/r6rM1j8k1DcnaKnbiCDq7W98sA6t1P2xSEAI=

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+IMAGE := amundsendev/amundsen-frontend
+VERSION:= $(shell grep -m 1 '__version__' setup.py | cut -d '=' -f 2 | tr -d "'" | tr -d '[:space:]')
+
 .PHONY: clean
 clean:
 	find . -name \*.pyc -delete
@@ -18,3 +21,16 @@ mypy:
 
 .PHONY: test
 test: test_unit lint mypy
+
+.PHONY: image
+image:
+	docker build -f public.Dockerfile -t ${IMAGE}:${VERSION} .
+	docker tag ${IMAGE}:${VERSION} ${IMAGE}:latest
+
+.PHONY: push-image
+push-image:
+	docker push ${IMAGE}:${VERSION}
+	docker push ${IMAGE}:latest
+
+.PHONY: build-push-image
+build-push-image: image push-image


### PR DESCRIPTION
### Summary of Changes

Add Travis publish step to push Docker image into Dockerhub

### Tests

Tested out Makefile locally. Testing publish to Travis is not feasible (too much effort AFAIK)

### Documentation

NA

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
