### PR TITLE
Added loading spinner for search requests

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/index.tsx
@@ -97,8 +97,11 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
       const params = qs.parse(this.props.location.search);
       const { searchTerm, pageIndex, selectedTab } = params;
       const { term, index, currentTab } = this.getSanitizedUrlParams(searchTerm, pageIndex, selectedTab);
+      const prevTerm = qs.parse(prevProps.location.search).searchTerm;
       this.setState({ selectedTab: currentTab });
-      this.props.searchAll(term, this.createSearchOptions(index, currentTab));
+      if (term !== prevTerm) {
+        this.props.searchAll(term, this.createSearchOptions(index, currentTab));
+      }
     }
   }
 
@@ -252,7 +255,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
       );
   };
 
-  renderTabs = () => {
+  renderContent = () => {
     if (this.props.isLoading) {
       return (<LoadingSpinner/>);
     }
@@ -269,7 +272,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
         <div className="row">
           <div className="col-xs-12 col-md-offset-1 col-md-10">
             <SearchBar handleValueSubmit={ this.onSearchBarSubmit } searchTerm={ searchTerm }/>
-            { this.renderTabs() }
+            { this.renderContent() }
           </div>
         </div>
       </div>

--- a/amundsen_application/static/js/components/SearchPage/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/index.tsx
@@ -97,8 +97,8 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
       const params = qs.parse(this.props.location.search);
       const { searchTerm, pageIndex, selectedTab } = params;
       const { term, index, currentTab } = this.getSanitizedUrlParams(searchTerm, pageIndex, selectedTab);
-      const prevTerm = qs.parse(prevProps.location.search).searchTerm;
       this.setState({ selectedTab: currentTab });
+      const prevTerm = qs.parse(prevProps.location.search).searchTerm;
       if (term !== prevTerm) {
         this.props.searchAll(term, this.createSearchOptions(index, currentTab));
       }

--- a/amundsen_application/static/js/components/SearchPage/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/index.tsx
@@ -98,7 +98,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
       const { searchTerm, pageIndex, selectedTab } = params;
       const { term, index, currentTab } = this.getSanitizedUrlParams(searchTerm, pageIndex, selectedTab);
       this.setState({ selectedTab: currentTab });
-      const prevTerm = qs.parse(prevProps.location.search).searchTerm;
+      const prevTerm = prevProps.searchTerm;
       if (term !== prevTerm) {
         this.props.searchAll(term, this.createSearchOptions(index, currentTab));
       }

--- a/amundsen_application/static/js/components/SearchPage/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/index.tsx
@@ -8,6 +8,7 @@ import { RouteComponentProps } from 'react-router';
 
 import SearchBar from './SearchBar';
 import SearchList from './SearchList';
+import LoadingSpinner from 'components/common/LoadingSpinner';
 
 import InfoButton from 'components/common/InfoButton';
 import { ResourceType, TableResource } from 'components/common/ResourceListItem/types';
@@ -47,6 +48,7 @@ import {
 
 export interface StateFromProps {
   searchTerm: string;
+  isLoading: boolean;
   popularTables: TableResource[];
   tables: TableSearchResults;
   dashboards: DashboardSearchResults;
@@ -250,6 +252,16 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
       );
   };
 
+  renderTabs = () => {
+    if (this.props.isLoading) {
+      return (<LoadingSpinner/>);
+    }
+    if (this.props.searchTerm.length > 0) {
+      return this.renderSearchResults();
+    }
+    return this.renderPopularTables();
+  };
+
   render() {
     const { searchTerm } = this.props;
     const innerContent = (
@@ -257,8 +269,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
         <div className="row">
           <div className="col-xs-12 col-md-offset-1 col-md-10">
             <SearchBar handleValueSubmit={ this.onSearchBarSubmit } searchTerm={ searchTerm }/>
-            { searchTerm.length > 0 && this.renderSearchResults() }
-            { searchTerm.length === 0 && this.renderPopularTables()  }
+            { this.renderTabs() }
           </div>
         </div>
       </div>
@@ -277,6 +288,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
 export const mapStateToProps = (state: GlobalState) => {
   return {
     searchTerm: state.search.search_term,
+    isLoading: state.search.isLoading,
     popularTables: state.popularTables,
     tables: state.search.tables,
     users: state.search.users,

--- a/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
@@ -35,6 +35,7 @@ describe('SearchPage', () => {
   const setup = (propOverrides?: Partial<SearchPageProps>) => {
     const props: SearchPageProps = {
       searchTerm: globalState.search.search_term,
+      isLoading: false,
       popularTables: globalState.popularTables,
       dashboards: globalState.search.dashboards,
       tables: globalState.search.tables,

--- a/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
@@ -228,67 +228,13 @@ describe('SearchPage', () => {
   });
 
   describe('componentDidUpdate', () => {
-    describe('called with a new search term', () => {
-      let props;
-      let wrapper;
-      let searchAllSpy;
-      
-      let mockSearchOptions;
-      let mockSanitizedUrlParams;
-
-      let createSearchOptionsSpy;
-      let getSanitizedUrlParamsSpy;
-
-      beforeAll(() => {
-        const setupResult = setup({
-          location: {
-            search: '/search?searchTerm=current&selectedTab=table&pageIndex=0', 
-            pathname: 'mockstr',
-            state: jest.fn(),
-            hash: 'mockstr',
-          }
-        });
-        props = setupResult.props;
-        wrapper = setupResult.wrapper;
-
-        mockSanitizedUrlParams = { 'term': 'current', ' index': 0, 'currentTab': 'table' };
-        getSanitizedUrlParamsSpy = jest.spyOn(wrapper.instance(), 'getSanitizedUrlParams').mockImplementation(() => {
-          return mockSanitizedUrlParams;
-        });
-
-        mockSearchOptions = { 'dashboardIndex': 0, 'tableIndex': 1, 'userIndex': 0 };
-        createSearchOptionsSpy = jest.spyOn(wrapper.instance(), 'createSearchOptions').mockImplementation(() => {
-          return mockSearchOptions;
-        });
-
-        searchAllSpy = jest.spyOn(props, 'searchAll');
-
-        setStateSpy.mockClear();
-
-        const mockPrevProps = {
-          location: {
-            search: '/search?searchTerm=previous&selectedTab=table&pageIndex=0', 
-            pathname: 'mockstr',
-            state: jest.fn(),
-            hash: 'mockstr',
-          }
-        };
-        wrapper.instance().componentDidUpdate(mockPrevProps);
-      });
-
-      it('calls setState', () => {
-        expect(setStateSpy).toHaveBeenCalledWith({ selectedTab: ResourceType.table });
-      });
-
-      it('calls searchAll', () => {
-        expect(searchAllSpy).toHaveBeenCalledWith(mockSanitizedUrlParams.term, mockSearchOptions);
-      });
-    });
-  });
-
-  describe('called with a new page but with the same search term', () => {
     let searchAllSpy;
+      
+    let mockSearchOptions;
+    let mockSanitizedUrlParams;
 
+    let createSearchOptionsSpy;
+    let getSanitizedUrlParamsSpy;
     beforeAll(() => {
       const {props, wrapper} = setup({
         location: {
@@ -299,14 +245,23 @@ describe('SearchPage', () => {
         }
       });
 
+      mockSanitizedUrlParams = { 'term': 'current', ' index': 0, 'currentTab': 'table' };
+      getSanitizedUrlParamsSpy = jest.spyOn(wrapper.instance(), 'getSanitizedUrlParams').mockImplementation(() => {
+        return mockSanitizedUrlParams;
+      });
+
+      mockSearchOptions = { 'dashboardIndex': 0, 'tableIndex': 1, 'userIndex': 0 };
+      createSearchOptionsSpy = jest.spyOn(wrapper.instance(), 'createSearchOptions').mockImplementation(() => {
+        return mockSearchOptions;
+      });
+
       searchAllSpy = jest.spyOn(props, 'searchAll');
 
-      searchAllSpy.mockClear();
       setStateSpy.mockClear();
 
       const mockPrevProps = {
         location: {
-          search: '/search?searchTerm=current&current=table&pageIndex=1', 
+          search: '/search?searchTerm=previous&selectedTab=table&pageIndex=0', 
           pathname: 'mockstr',
           state: jest.fn(),
           hash: 'mockstr',
@@ -315,9 +270,47 @@ describe('SearchPage', () => {
       wrapper.instance().componentDidUpdate(mockPrevProps);
     });
 
-    it('calls searchAll', () => {
-      expect(searchAllSpy).not.toHaveBeenCalled();
+    describe('called with a new search term', () => {
+      it('calls setState', () => {
+        expect(setStateSpy).toHaveBeenCalledWith({ selectedTab: ResourceType.table });
+      });
+
+      it('calls searchAll', () => {
+        expect(searchAllSpy).toHaveBeenCalledWith(mockSanitizedUrlParams.term, mockSearchOptions);
+      });
     });
+
+    describe('called with a new page but with the same search term', () => {  
+      beforeAll(() => {
+        const {props, wrapper} = setup({
+          location: {
+            search: '/search?searchTerm=current&selectedTab=table&pageIndex=0', 
+            pathname: 'mockstr',
+            state: jest.fn(),
+            hash: 'mockstr',
+          }
+        });
+  
+        searchAllSpy = jest.spyOn(props, 'searchAll');
+  
+        searchAllSpy.mockClear();
+        setStateSpy.mockClear();
+  
+        const mockPrevProps = {
+          location: {
+            search: '/search?searchTerm=current&current=table&pageIndex=1', 
+            pathname: 'mockstr',
+            state: jest.fn(),
+            hash: 'mockstr',
+          }
+        };
+        wrapper.instance().componentDidUpdate(mockPrevProps);
+      });
+  
+      it('does not call searchAll', () => {
+        expect(searchAllSpy).not.toHaveBeenCalled();
+      });
+    });  
   });
 
   describe('getSanitizedUrlParams', () => {
@@ -656,12 +649,12 @@ describe('SearchPage', () => {
         content = shallow(wrapper.instance().renderContent());
       });
       
-      it('renders correct label for content', () => {
+      it('renders popular tables', () => {
         expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderPopularTables());
       });
     });
 
-    describe('search tables', () => {
+    describe('search results', () => {
       beforeAll(() => {
         const setupResult = setup({ searchTerm: 'test' });
         props = setupResult.props;
@@ -669,7 +662,7 @@ describe('SearchPage', () => {
         content = shallow(wrapper.instance().renderContent());
       });
       
-      it('renders correct label for content', () => {
+      it('renders search result', () => {
         expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderSearchResults());
       });
     });
@@ -682,7 +675,7 @@ describe('SearchPage', () => {
         content = shallow(wrapper.instance().renderContent());
       });
       
-      it('renders correct label for content', () => {
+      it('renders loading spinner', () => {
         expect(wrapper.instance().renderContent()).toEqual(<LoadingSpinner/>);
       });
     });
@@ -809,7 +802,7 @@ describe('mapStateToProps', () => {
     expect(result.searchTerm).toEqual(globalState.search.search_term);
   });
 
-  it('sets searchTerm on the props', () => {
+  it('sets isLoading on the props', () => {
     expect(result.isLoading).toEqual(globalState.search.isLoading);
   });
 

--- a/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/tests/index.spec.tsx
@@ -235,8 +235,11 @@ describe('SearchPage', () => {
 
     let createSearchOptionsSpy;
     let getSanitizedUrlParamsSpy;
+
+    let props;
+    let wrapper;
     beforeAll(() => {
-      const {props, wrapper} = setup({
+      const setupResult = setup({
         location: {
           search: '/search?searchTerm=current&selectedTab=table&pageIndex=0', 
           pathname: 'mockstr',
@@ -244,6 +247,8 @@ describe('SearchPage', () => {
           hash: 'mockstr',
         }
       });
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
 
       mockSanitizedUrlParams = { 'term': 'current', ' index': 0, 'currentTab': 'table' };
       getSanitizedUrlParamsSpy = jest.spyOn(wrapper.instance(), 'getSanitizedUrlParams').mockImplementation(() => {
@@ -260,6 +265,7 @@ describe('SearchPage', () => {
       setStateSpy.mockClear();
 
       const mockPrevProps = {
+        searchTerm: 'previous',
         location: {
           search: '/search?searchTerm=previous&selectedTab=table&pageIndex=0', 
           pathname: 'mockstr',
@@ -270,47 +276,28 @@ describe('SearchPage', () => {
       wrapper.instance().componentDidUpdate(mockPrevProps);
     });
 
-    describe('called with a new search term', () => {
-      it('calls setState', () => {
-        expect(setStateSpy).toHaveBeenCalledWith({ selectedTab: ResourceType.table });
-      });
-
-      it('calls searchAll', () => {
-        expect(searchAllSpy).toHaveBeenCalledWith(mockSanitizedUrlParams.term, mockSearchOptions);
-      });
+    it('calls setState', () => {
+      expect(setStateSpy).toHaveBeenCalledWith({ selectedTab: ResourceType.table });
     });
 
-    describe('called with a new page but with the same search term', () => {  
-      beforeAll(() => {
-        const {props, wrapper} = setup({
-          location: {
-            search: '/search?searchTerm=current&selectedTab=table&pageIndex=0', 
-            pathname: 'mockstr',
-            state: jest.fn(),
-            hash: 'mockstr',
-          }
-        });
-  
-        searchAllSpy = jest.spyOn(props, 'searchAll');
-  
-        searchAllSpy.mockClear();
-        setStateSpy.mockClear();
-  
-        const mockPrevProps = {
-          location: {
-            search: '/search?searchTerm=current&current=table&pageIndex=1', 
-            pathname: 'mockstr',
-            state: jest.fn(),
-            hash: 'mockstr',
-          }
-        };
-        wrapper.instance().componentDidUpdate(mockPrevProps);
-      });
-  
-      it('does not call searchAll', () => {
-        expect(searchAllSpy).not.toHaveBeenCalled();
-      });
-    });  
+    it('calls searchAll if called with a new search term', () => {
+      expect(searchAllSpy).toHaveBeenCalledWith(mockSanitizedUrlParams.term, mockSearchOptions);
+    });
+
+    it('does not call searchAll if called with the same search term with a new page', () => {
+      searchAllSpy.mockClear();
+      const mockPrevProps = {
+        searchTerm: 'current',
+        location: {
+          search: '/search?searchTerm=current&current=table&pageIndex=1', 
+          pathname: 'mockstr',
+          state: jest.fn(),
+          hash: 'mockstr',
+        }
+      };
+      wrapper.instance().componentDidUpdate(mockPrevProps);
+      expect(searchAllSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('getSanitizedUrlParams', () => {
@@ -638,46 +625,19 @@ describe('SearchPage', () => {
   });
 
   describe('renderContent', () => {
-    let content;
-    let props;
-    let wrapper;
-    describe('popular tables', () => {
-      beforeAll(() => {
-        const setupResult = setup({ searchTerm: '' });
-        props = setupResult.props;
-        wrapper = setupResult.wrapper;
-        content = shallow(wrapper.instance().renderContent());
-      });
-      
-      it('renders popular tables', () => {
-        expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderPopularTables());
-      });
+    it('renders popular tables if searchTerm is empty', () => {
+      const {props, wrapper} = setup({ searchTerm: '' });
+      expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderPopularTables());
     });
 
-    describe('search results', () => {
-      beforeAll(() => {
-        const setupResult = setup({ searchTerm: 'test' });
-        props = setupResult.props;
-        wrapper = setupResult.wrapper;
-        content = shallow(wrapper.instance().renderContent());
-      });
-      
-      it('renders search result', () => {
-        expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderSearchResults());
-      });
+    it('renders search results when given search term', () => {
+      const {props, wrapper} = setup({ searchTerm: 'test' });
+      expect(wrapper.instance().renderContent()).toEqual(wrapper.instance().renderSearchResults());
     });
 
-    describe('loading state', () => {
-      beforeAll(() => {
-        const setupResult = setup({ isLoading: true });
-        props = setupResult.props;
-        wrapper = setupResult.wrapper;
-        content = shallow(wrapper.instance().renderContent());
-      });
-      
-      it('renders loading spinner', () => {
-        expect(wrapper.instance().renderContent()).toEqual(<LoadingSpinner/>);
-      });
+    it('renders loading spinner when in loading state', () => {
+      const {props, wrapper} = setup({ isLoading: true });
+      expect(wrapper.instance().renderContent()).toEqual(<LoadingSpinner/>);
     });
   });
 

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -12,10 +12,17 @@ import {
 } from './types';
 import { ResourceType } from 'components/common/ResourceListItem/types';
 
-export type SearchReducerAction = SearchAllResponse | SearchResourceResponse | SearchAllRequest;
+import {
+  GetPopularTables,
+  GetPopularTablesRequest,
+  GetPopularTablesResponse,
+} from 'ducks/popularTables/types';
+
+export type SearchReducerAction = SearchAllResponse | SearchResourceResponse | SearchAllRequest | GetPopularTablesResponse;
 
 export interface SearchReducerState {
   search_term: string;
+  isLoading: boolean;
   dashboards: DashboardSearchResults;
   tables: TableSearchResults;
   users: UserSearchResults;
@@ -40,6 +47,7 @@ export function searchResource(resource: ResourceType, term: string, pageIndex: 
 
 const initialState: SearchReducerState = {
   search_term: '',
+  isLoading: true,
   dashboards: {
     page_index: 0,
     results: [],
@@ -64,6 +72,7 @@ export default function reducer(state: SearchReducerState = initialState, action
       return {
         ...state,
         search_term: action.term,
+        isLoading: true,
       };
     // SearchAll will reset all resources with search results or the initial state
     case SearchAll.SUCCESS:
@@ -71,6 +80,7 @@ export default function reducer(state: SearchReducerState = initialState, action
       return {
         ...initialState,
         ...newState,
+        isLoading: false,
       };
     // SearchResource will set only a single resource and preserves search state for other resources
     case SearchResource.SUCCESS:
@@ -78,11 +88,23 @@ export default function reducer(state: SearchReducerState = initialState, action
       return {
         ...state,
         ...resourceNewState,
+        isLoading: false,
       };
     case SearchAll.FAILURE:
     case SearchResource.FAILURE:
-      return initialState;
+      return {
+        ...initialState,
+        isLoading: false,
+      };      
+    case GetPopularTables.SUCCESS:
+    case GetPopularTables.FAILURE:
+      return {
+        ...state,
+        isLoading: false,
+      };
     default:
-      return state;
+      return {
+        ...state
+      };
   }
 }

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -63,10 +63,14 @@ export default function reducer(state: SearchReducerState = initialState, action
   switch (action.type) {
     // Updates search term to reflect action
     case SearchAll.ACTION:
-    case SearchResource.ACTION:
       return {
         ...state,
         search_term: action.term,
+        isLoading: true,
+      };
+    case SearchResource.ACTION:
+      return {
+        ...state,
         isLoading: true,
       };
     // SearchAll will reset all resources with search results or the initial state

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -12,13 +12,7 @@ import {
 } from './types';
 import { ResourceType } from 'components/common/ResourceListItem/types';
 
-import {
-  GetPopularTables,
-  GetPopularTablesRequest,
-  GetPopularTablesResponse,
-} from 'ducks/popularTables/types';
-
-export type SearchReducerAction = SearchAllResponse | SearchResourceResponse | SearchAllRequest | GetPopularTablesResponse;
+export type SearchReducerAction = SearchAllResponse | SearchResourceResponse | SearchAllRequest | SearchResourceRequest;
 
 export interface SearchReducerState {
   search_term: string;
@@ -47,7 +41,7 @@ export function searchResource(resource: ResourceType, term: string, pageIndex: 
 
 const initialState: SearchReducerState = {
   search_term: '',
-  isLoading: true,
+  isLoading: false,
   dashboards: {
     page_index: 0,
     results: [],
@@ -69,6 +63,7 @@ export default function reducer(state: SearchReducerState = initialState, action
   switch (action.type) {
     // Updates search term to reflect action
     case SearchAll.ACTION:
+    case SearchResource.ACTION:
       return {
         ...state,
         search_term: action.term,
@@ -96,15 +91,7 @@ export default function reducer(state: SearchReducerState = initialState, action
         ...initialState,
         isLoading: false,
       };      
-    case GetPopularTables.SUCCESS:
-    case GetPopularTables.FAILURE:
-      return {
-        ...state,
-        isLoading: false,
-      };
     default:
-      return {
-        ...state
-      };
+      return state;
   }
 }

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -41,6 +41,7 @@ const globalState: GlobalState = {
   ],
   search: {
     search_term: 'testName',
+    isLoading: true,
     dashboards: {
       page_index: 0,
       results: [],

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -41,7 +41,7 @@ const globalState: GlobalState = {
   ],
   search: {
     search_term: 'testName',
-    isLoading: true,
+    isLoading: false,
     dashboards: {
       page_index: 0,
       results: [],


### PR DESCRIPTION
### Summary of Changes

Title, we needed some form of loading state so that delays between search requests wouldn't look awkward. There's a small hack here where we need to handle GetPopularTables actions from the Search reducer but this'll be addressed in a follow up with the decoupling of popular tables and search in the new home page

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
