### PR TITLE
WIP: Make 'key' able to serve the unique identifiers in both Atlas (GUID) and Neo4j (table_uri)

### DIFF
--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -11,7 +11,7 @@ from amundsen_application.log.action_log import action_logging
 
 from amundsen_application.models.user import load_user, dump_user
 
-from amundsen_application.api.utils.metadata_utils import marshall_table_partial, marshall_table_full
+from amundsen_application.api.utils.metadata_utils import marshall_table_full
 from amundsen_application.api.utils.request_utils import get_query_param, request_metadata
 
 
@@ -52,7 +52,7 @@ def popular_tables() -> Response:
             message = 'Success'
             response_list = response.json().get('popular_tables')
             top4 = response_list[0:min(len(response_list), app.config['POPULAR_TABLE_COUNT'])]
-            popular_tables = [marshall_table_partial(result) for result in top4]
+            popular_tables = [result for result in top4]
         else:
             message = 'Encountered error: Request to metadata service failed with status code ' + str(status_code)
             logging.error(message)
@@ -441,7 +441,7 @@ def get_bookmark() -> Response:
         status_code = response.status_code
 
         tables = response.json().get('table')
-        table_bookmarks = [marshall_table_partial(table) for table in tables]
+        table_bookmarks = [table for table in tables]
 
         return make_response(jsonify({'msg': 'success', 'bookmarks': table_bookmarks}), status_code)
     except Exception as e:

--- a/amundsen_application/api/utils/metadata_utils.py
+++ b/amundsen_application/api/utils/metadata_utils.py
@@ -4,30 +4,6 @@ from flask import current_app as app
 from amundsen_application.models.user import load_user, dump_user
 
 
-def marshall_table_partial(table: Dict) -> Dict:
-    """
-    Forms a short version of a table Dict, with selected fields and an added 'key'
-    :param table: Dict of partial table object
-    :return: partial table Dict
-
-    TODO - Unify data format returned by search and metadata.
-    """
-    table_name = table.get('table_name', '')
-    schema_name = table.get('schema', '')
-    cluster = table.get('cluster', '')
-    db = table.get('database', '')
-    return {
-        'cluster': cluster,
-        'database': db,
-        'description': table.get('table_description', ''),
-        'key': '{0}://{1}.{2}/{3}'.format(db, cluster, schema_name, table_name),
-        'name': table_name,
-        'schema_name': schema_name,
-        'type': 'table',
-        'last_updated_epoch': table.get('last_updated_epoch', None),
-    }
-
-
 def marshall_table_full(table: Dict) -> Dict:
     """
     Forms the full version of a table Dict, with additional and sanitized fields

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -98,14 +98,16 @@ export class TableDetail extends React.Component<TableDetailProps & RouteCompone
     this.database = params ? params.db : '';
     this.schema = params ? params.schema : '';
     this.tableName = params ? params.table : '';
+    this.key = params ? params.key : '';
     this.displayName = params ? `${this.schema}.${this.tableName}` : '';
 
     /*
-    This 'key' is the `table_uri` format described in metadataservice. Because it contains the '/' character,
+    This 'key' could be GUID for Atlas proxy or 'table_uri' for Neo4j proxy.
+    If 'key' is the `table_uri` format described in metadataservice. Because it contains the '/' character,
     we can't pass it as a single URL parameter without encodeURIComponent which makes ugly URLs.
     DO NOT CHANGE
     */
-    this.key = params ? `${this.database}://${this.cluster}.${this.schema}/${this.tableName}` : '';
+    this.key = this.key.includes(`/`) ? `${this.database}://${this.cluster}.${this.schema}/${this.tableName}` : this.key;
 
     this.state = {
       isLoading: props.isLoading,

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -20,15 +20,16 @@ class MetadataTest(unittest.TestCase):
                 {
                     'cluster': 'test_cluster',
                     'database': 'test_db',
+                    'description': 'This is a test',
                     'key': 'test_db://test_cluster.test_schema/test_table',
-                    'schema': 'test_schema',
-                    'table_description': 'This is a test',
-                    'table_name': 'test_table',
+                    'schema_name': 'test_schema',
                     'type': 'table',
+                    'name': 'test_table',
+                    'last_updated_epoch': None,
                 }
             ]
         }
-        self.expected_parsed_popular_tables = [
+        self.expected_popular_table = [
             {
                 'cluster': 'test_cluster',
                 'database': 'test_db',
@@ -206,20 +207,26 @@ class MetadataTest(unittest.TestCase):
                 {
                     'cluster': 'cluster',
                     'database': 'database',
-                    'schema': 'schema',
-                    'table_name': 'table_name_0',
-                    'table_description': 'description',
+                    'description': 'description',
+                    'key': 'database://cluster.schema/table_name_0',
+                    'last_updated_epoch': None,
+                    'name': 'table_name_0',
+                    'schema_name': 'schema',
+                    'type': 'table',
                 },
                 {
                     'cluster': 'cluster',
                     'database': 'database',
-                    'schema': 'schema',
-                    'table_name': 'table_name_1',
-                    'table_description': 'description',
+                    'description': 'description',
+                    'key': 'database://cluster.schema/table_name_1',
+                    'last_updated_epoch': None,
+                    'name': 'table_name_1',
+                    'schema_name': 'schema',
+                    'type': 'table',
                 },
             ]
         }
-        self.expected_parsed_bookmarks = [
+        self.expected_bookmarks = [
             {
                 'cluster': 'cluster',
                 'database': 'database',
@@ -255,7 +262,7 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/popular_tables')
             data = json.loads(response.data)
             self.assertEqual(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('results'), self.expected_parsed_popular_tables)
+            self.assertCountEqual(data.get('results'), self.expected_popular_table)
 
     @responses.activate
     def test_popular_tables_propagate_failure(self) -> None:
@@ -567,7 +574,7 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user/bookmark')
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('bookmarks'), self.expected_parsed_bookmarks)
+            self.assertCountEqual(data.get('bookmarks'), self.expected_bookmarks)
 
     @responses.activate
     def test_get_bookmark_for_user(self) -> None:
@@ -582,7 +589,7 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user/bookmark', query_string=dict(user_id=specified_user))
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('bookmarks'), self.expected_parsed_bookmarks)
+            self.assertCountEqual(data.get('bookmarks'), self.expected_bookmarks)
 
     @responses.activate
     def test_put_bookmark(self) -> None:


### PR DESCRIPTION
### Summary of Changes

* Remove <code>marshall_table_partial</code>, metadata responses with the parsed table
* Make the <code>key</code> could serve both GUID for Atlas proxy and table_uri for Neo4j

### Tests

* Correct the tests related to tables

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
