### PR TITLE
Updated mail client calls to reflect changes in private

### DIFF
--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -47,7 +47,11 @@ def feedback() -> Response:
                   value_prop=value_prop,
                   subject=subject)
 
-        response = mail_client.send_email(subject=subject, text=text_content, html=html_content, optional_data=data)
+        options = {
+            'email_type': 'feedback',
+            'form_data': data
+        }
+        response = mail_client.send_email(subject=subject, text=text_content, html=html_content, options=options)
         status_code = response.status_code
 
         if status_code == HTTPStatus.OK:

--- a/amundsen_application/base/base_mail_client.py
+++ b/amundsen_application/base/base_mail_client.py
@@ -16,7 +16,7 @@ class BaseMailClient(abc.ABC):
                    subject: str,
                    text: str,
                    html: str,
-                   optional_data: Dict) -> Response:
+                   options: Dict) -> Response:
         """
         Sends an email using the following parameters
         :param sender: The sending address associated with the email
@@ -24,7 +24,7 @@ class BaseMailClient(abc.ABC):
         :param subject: The subject of the email
         :param text: Plain text email content
         :param html: HTML email content
-        :param optional_data: A dictionary of any values needed for custom implementations
+        :param options: A dictionary of any values needed for custom implementations
         :return:
         """
         raise NotImplementedError  # pragma: no cover

--- a/tests/unit/api/mail/test_v0.py
+++ b/tests/unit/api/mail/test_v0.py
@@ -21,7 +21,7 @@ class MockMailClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   optional_data: Dict = {}) -> Response:
+                   options: Dict = {}) -> Response:
         return make_response(jsonify({}), self.status_code)
 
 
@@ -35,7 +35,7 @@ class MockBadClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   optional_data: Dict = {}) -> Response:
+                   options: Dict = {}) -> Response:
         raise Exception('Bad client')
 
 


### PR DESCRIPTION
### Summary of Changes

Changed basemailclient parameter naming to make a bit more sense. Fixed calls to send_email to expect this object for options:

```
options: {
   email_type: string,
   form_data: {previous 'optional_data'}
}
```

### Tests

None needed

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
