### PR TITLE
Fix preview data error handling

### DIFF
--- a/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -146,5 +146,10 @@ export function getPreviewData(queryParams: PreviewQueryParams) {
   })
   .then((response: AxiosResponse<PreviewDataAPI>) => {
     return { data: response.data.previewData, status: response.status };
+  })
+  .catch((e: AxiosError<PreviewDataAPI>) => {
+    const data = e.response ? e.response.data.previewData : {};
+    const status = e.response ? e.response.status : null;
+    return Promise.reject({ data, status });
   });
 }

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -129,9 +129,8 @@ export function* getPreviewDataWorker(action: GetPreviewDataRequest): SagaIterat
     const response = yield call(API.getPreviewData, action.payload.queryParams);
     const { data, status } = response;
     yield put(getPreviewDataSuccess(data, status));
-  } catch (e) {
-    const data = e.response ? e.response.data : {};
-    const status = e.response ? e.response.status : null;
+  } catch (error) {
+    const { data, status } = error;
     yield put(getPreviewDataFailure(data, status));
   }
 };

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -585,16 +585,9 @@ describe('reducer', () => {
       });
 
       it('handles request error', () => {
-        const mockErrorResponse = { name: '', message: '', response: { data: previewData, status: 500 }};
+        const mockErrorResponse = { data: previewData, status: 500 };
         testSaga(getPreviewDataWorker, getPreviewData(queryParams))
           .next().throw(mockErrorResponse).put(getPreviewDataFailure(previewData, 500))
-          .next().isDone();
-      });
-
-      it('handles request error with response fallbacks', () => {
-        const mockErrorResponse = { name: '', message: '' };
-        testSaga(getPreviewDataWorker, getPreviewData(queryParams))
-          .next().throw(mockErrorResponse).put(getPreviewDataFailure({}, null))
           .next().isDone();
       });
     });

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -577,17 +577,17 @@ describe('reducer', () => {
 
     describe('getPreviewDataWorker', () => {
       it('executes flow for getting preview data', () => {
-        const mockResponse = { data: previewData, status: 200 };
         testSaga(getPreviewDataWorker, getPreviewData(queryParams))
           .next().call(API.getPreviewData, queryParams)
-          .next(mockResponse).put(getPreviewDataSuccess(previewData, 200))
+          .next({ data: previewData, status: 200 }).put(getPreviewDataSuccess(previewData, 200))
           .next().isDone();
       });
 
       it('handles request error', () => {
-        const mockErrorResponse = { data: previewData, status: 500 };
         testSaga(getPreviewDataWorker, getPreviewData(queryParams))
-          .next().throw(mockErrorResponse).put(getPreviewDataFailure(previewData, 500))
+          .next().call(API.getPreviewData, queryParams)
+          // @ts-ignore TODO: Investigate why redux-saga-test-plan throw() complains
+          .throw({ data: previewData, status: 500 }).put(getPreviewDataFailure(previewData, 500))
           .next().isDone();
       });
     });


### PR DESCRIPTION
### Summary of Changes

This PR fixes a bug with the `error_text` from a preview data failure not getting passed back to the frontend. 
1. The source of the bug was that in our error response handling, we passed back `e.response.data` when we needed to pass back `e.response.data.previewData`. 
2. I also realized we were processing the `axios` success response in the api call, yet processing the error response in the saga. All the `axios` response handling should have been part of the api call.

### Tests

Updated saga tests to account for the new logic. This bug also exposes the fact that we need to complete unit test coverage to our `tableMetadata` apis to ensure we are handling responses correctly -- I have an internal ticket filed to complete this when I have the bandwidth.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
