### PR TITLE
Remove timeout on feedback submission api call

### DIFF
--- a/amundsen_application/static/js/ducks/feedback/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/feedback/api/tests/index.spec.ts
@@ -16,7 +16,6 @@ describe('submitFeedback', () => {
       data: formData,
       method: 'post',
       url: '/api/mail/v0/feedback',
-      timeout: 5000,
       headers: {'Content-Type': 'multipart/form-data' }
     })
   });

--- a/amundsen_application/static/js/ducks/feedback/api/v0.ts
+++ b/amundsen_application/static/js/ducks/feedback/api/v0.ts
@@ -5,7 +5,6 @@ export function submitFeedback(data: FormData) {
     data,
     method: 'post',
     url: '/api/mail/v0/feedback',
-    timeout: 5000,
     headers: {'Content-Type': 'multipart/form-data' }
   });
 }


### PR DESCRIPTION
### Summary of Changes

I cannot remember the context of why this was added, and I wonder if this was a copy paste mistake. There is no reason for this api to have a timeout, and it risks causing issues if someone's custom mail client takes longer than that to complete the request. 

### Tests

Updated api test.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
