### PR TITLE
Add db to tablelistitem + re-add database to syntax help text

### DIFF
--- a/amundsen_application/static/css/_typography-default.scss
+++ b/amundsen_application/static/css/_typography-default.scss
@@ -125,6 +125,12 @@ body {
   font-family: $font-family-monospace;
 }
 
+.resource-type {
+  color: $gray;
+  font-size: 13px;
+  font-family: $font-family-monospace;
+}
+
 .helper-text {
   color: $text-medium;
   font-size: 12px;

--- a/amundsen_application/static/js/components/SearchPage/SearchBar/constants.ts
+++ b/amundsen_application/static/js/components/SearchPage/SearchBar/constants.ts
@@ -4,7 +4,7 @@ export const ERROR_CLASSNAME = 'error';
 export const PLACEHOLDER_DEFAULT = 'search for data resources...';
 
 export const SUBTEXT_DEFAULT = `Search within a category using the pattern with wildcard support 'category:*searchTerm*', e.g. 'schema:*core*'.
-  Current categories are 'column', 'schema', 'table', and 'tag'.`;
+  Current categories are 'column', 'database', 'schema', 'table', and 'tag'.`;
 export const SYNTAX_ERROR_CATEGORY = `Advanced search syntax only supports searching one category. Please remove all extra ':'`;
 export const SYNTAX_ERROR_PREFIX = 'Did you mean ';
 export const SYNTAX_ERROR_SPACING_SUFFIX = ` ? Please remove the space around the ':'.`;

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
@@ -38,7 +38,7 @@ class TableListItem extends React.Component<TableListItemProps, {}> {
         <Link className="resource-list-item table-list-item" to={ this.getLink() }>
           <img className="icon icon-database icon-color" />
           <div className="content">
-            <div className={ hasLastUpdated? "col-sm-9 col-md-10" : "col-sm-12"}>
+            <div className="col-sm-6 col-md-8">
               <div className="resource-name title-2">
                 <div className="truncated">
                   { `${table.schema_name}.${table.name}`}
@@ -46,6 +46,9 @@ class TableListItem extends React.Component<TableListItemProps, {}> {
                 <BookmarkIcon bookmarkKey={ this.props.table.key }/>
               </div>
               <div className="body-secondary-3 truncated">{ table.description }</div>
+            </div>
+            <div className="resource-type hidden-xs col-sm-3 col-md-2 text-center">
+              { table.database }
             </div>
             {
               hasLastUpdated &&

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -14,7 +14,7 @@ describe('TableListItem', () => {
       table: {
         type: ResourceType.table,
         cluster: '',
-        database: '',
+        database: 'testdb',
         description: 'I am the description',
         key: '',
         last_updated_epoch: 1553829681,
@@ -52,13 +52,17 @@ describe('TableListItem', () => {
       expect(wrapper.find('.content').children().at(0).children().at(1).text()).toEqual('I am the description');
     });
 
+    it('renders resource type', () => {
+      expect(wrapper.find('.content').children().at(1).text()).toEqual(props.table.database);
+    });
+
     describe('if props.table has last_updated_epoch', () => {
       it('renders Last Update title', () => {
-        expect(wrapper.find('.content').children().at(1).children().at(0).text()).toEqual('Last Updated');
+        expect(wrapper.find('.content').children().at(2).children().at(0).text()).toEqual('Last Updated');
       });
 
       it('renders getDateLabel value', () => {
-        expect(wrapper.find('.content').children().at(1).children().at(1).text()).toEqual(wrapper.instance().getDateLabel());
+        expect(wrapper.find('.content').children().at(2).children().at(1).text()).toEqual(wrapper.instance().getDateLabel());
       });
     });
 
@@ -74,7 +78,7 @@ describe('TableListItem', () => {
           name: 'tableName',
           schema_name: 'tableSchema',
         }});
-        expect(wrapper.find('.content').children().at(1).exists()).toBeFalsy();
+        expect(wrapper.find('.content').children().at(2).exists()).toBeFalsy();
       });
     });
   });


### PR DESCRIPTION
### Summary of Changes

1. Adds back in the `database` option to the advanced search syntax help text.
2. Renders the `database` value in `TableListItem`. This is a stop gap implementation until our new designs are complete -- the `TableListItem` in this PR intentionally does not fully match the new designs.
![image](https://user-images.githubusercontent.com/1790900/62160263-650c0280-b2c8-11e9-8ad1-eb2be0dbbf37.png)

### Tests

Update `TableListItem` tests.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
