### PR TITLE
Bump minimum supported Python to 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or with an [Airflow DAG](https://github.com/lyft/amundsendatabuilder/blob/master
 
 
 ## Requirements
-- Python >= 3.4
+- Python >= 3.5
 - Node = v8.x.x or v10.x.x (v11.x.x has compatibility issues)
 - npm >= 6.x.x
 


### PR DESCRIPTION
https://docs.python.org/3.4/library/http.html says 3.4 isn’t supported any more.

https://github.com/lyft/amundsen/issues/30 gives background on that we are in fact not able to build with 3.4

### Summary of Changes

_Include a summary of changes then remove this line_

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
