### PR TITLE
Wire up query-string endpoint

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchBar/index.tsx
@@ -54,7 +54,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
   }
 
   handleValueChange = (event: React.SyntheticEvent<HTMLInputElement>) : void => {
-    this.setState({ searchTerm: (event.target as HTMLInputElement).value.toLowerCase() });
+    this.setState({ searchTerm: (event.target as HTMLInputElement).value });
   };
 
   handleValueSubmit = (event: React.FormEvent<HTMLFormElement>) : void => {
@@ -65,20 +65,11 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
       if (searchTerm !== '') {
         pathName = `/search?searchTerm=${searchTerm}`;
       }
-      this.props.history.push(pathName);    
+      this.props.history.push(pathName);
     }
   };
 
   isFormValid = (searchTerm: string) : boolean => {
-    const hasAtMostOneCategory = searchTerm.split(':').length <= 2;
-    if (!hasAtMostOneCategory) {
-      this.setState({
-        subText: SYNTAX_ERROR_CATEGORY,
-        subTextClassName: ERROR_CLASSNAME,
-      });
-      return false;
-    }
-
     const colonIndex = searchTerm.indexOf(':');
     const hasNoSpaceAroundColon = colonIndex < 0 ||
       (colonIndex >= 1 && searchTerm.charAt(colonIndex+1) !== " " &&  searchTerm.charAt(colonIndex-1) !== " ");

--- a/amundsen_application/static/js/components/SearchPage/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchBar/tests/index.spec.tsx
@@ -63,7 +63,7 @@ describe('SearchBar', () => {
       const { props, wrapper } = setup();
       // @ts-ignore: mocked events throw type errors
       wrapper.instance().handleValueChange(valueChangeMockEvent);
-      expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: valueChangeMockEvent.target.value.toLowerCase() });
+      expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: valueChangeMockEvent.target.value });
     });
   });
 
@@ -99,7 +99,7 @@ describe('SearchBar', () => {
 
     it('does not submit if !isFormValid()', () => {
       historyPushSpy.mockClear();
-      const { props, wrapper } = setup({ searchTerm: 'tag:tag1 tag:tag2' });
+      const { props, wrapper } = setup({ searchTerm: 'tag : tag1 tag:tag2' });
       // @ts-ignore: mocked events throw type errors
       wrapper.instance().handleValueSubmit(submitMockEvent);
       expect(historyPushSpy).not.toHaveBeenCalled();
@@ -114,15 +114,7 @@ describe('SearchBar', () => {
       })
 
       it('returns false', () => {
-        expect(wrapper.instance().isFormValid('tag:tag1 tag:tag2')).toEqual(false);
-      });
-
-      it('sets state.subText correctly', () => {
-        expect(wrapper.state().subText).toEqual(SYNTAX_ERROR_CATEGORY);
-      });
-
-      it('sets state.subTextClassName correctly', () => {
-        expect(wrapper.state().subTextClassName).toEqual(ERROR_CLASSNAME);
+        expect(wrapper.instance().isFormValid('tag:tag1 tag:tag2')).toEqual(true);
       });
     });
 


### PR DESCRIPTION
### Summary of Changes

This PR is to show how we are wiring up this PR https://github.com/lyft/amundsensearchlibrary/pull/51 at Square.

It will allow users to search using the full capabilities of Elasticsearch's built in lucene query parser

### Tests

I updated tests so that multiple search fields are allowed in search

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
