### PR TITLE
[WIP] Typeahead Feature

### DIFF
--- a/amundsen_application/static/css/_variables-default.scss
+++ b/amundsen_application/static/css/_variables-default.scss
@@ -94,6 +94,8 @@ $label-primary-bg: $brand-color-3 !default;
 
 // TODO Temp Colors
 $resource-title-color: #8B37FF; // this is #purple60, end goal is #indigo60
+$call-to-action-color: #8B37FF; // temp name, this is #purple60, end goal is #indigo60
+
 $badge-text-color: #292936; // gray100
 $badge-danger-color: #FFCCBF; // sunset10
 $badge-primary-color: #D4F0FF; // cyan10

--- a/amundsen_application/static/js/components/NavBar/styles.scss
+++ b/amundsen_application/static/js/components/NavBar/styles.scss
@@ -12,45 +12,6 @@
   flex-direction: row;
   align-items: center;
 
-  .title-3 {
-    color: white;
-  }
-
-  a {
-    display: inline-block;
-    height: 100%;
-    line-height: 32px;
-    text-decoration: none;
-    color: white;
-    padding-left: 8px;
-    padding-right: 8px;
-
-    &:hover:not(.nav-bar-avatar-link),
-    &.active {
-      border-bottom: 4px solid white;
-    }
-
-    &.nav-bar-avatar-link {
-      margin-top: -4px;
-      padding-left: 4px;
-      padding-right: 4px;
-
-      .nav-bar-avatar {
-        height: 40px;
-        width: 40px;
-        padding: 4px;
-
-        &:hover {
-          /* override border-bottom style */
-          border-bottom: none;
-          /* circular background */
-          background-color: white;
-          border-radius: 50%;
-        }
-      }
-    }
-  }
-
   .nav-bar-left {
     flex-basis: 234px;
   }
@@ -64,6 +25,45 @@
   .nav-bar-right {
     height: 100%;
     padding-top: 12px;
+
+    .title-3 {
+      color: white;
+    }
+
+    a {
+      display: inline-block;
+      height: 100%;
+      line-height: 32px;
+      text-decoration: none;
+      color: white;
+      padding-left: 8px;
+      padding-right: 8px;
+
+      &:hover:not(.nav-bar-avatar-link),
+      &.active {
+        border-bottom: 4px solid white;
+      }
+
+      &.nav-bar-avatar-link {
+        margin-top: -4px;
+        padding-left: 4px;
+        padding-right: 4px;
+
+        .nav-bar-avatar {
+          height: 40px;
+          width: 40px;
+          padding: 4px;
+
+          &:hover {
+            /* override border-bottom style */
+            border-bottom: none;
+            /* circular background */
+            background-color: white;
+            border-radius: 50%;
+          }
+        }
+      }
+    }
   }
 
   .nav-bar-right > *:not(:last-child) {

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResourceSearchList/SearchItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResourceSearchList/SearchItem/index.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { ResourceType } from 'interfaces';
+
+export interface SearchItemProps {
+  listItemText: string;
+  onItemSelect: (event: Event) => void;
+  searchTerm: string;
+  resourceType: ResourceType;
+}
+
+const SearchItem: React.SFC<SearchItemProps> = ({ listItemText, onItemSelect, searchTerm, resourceType }) => {
+  // TODO: Will I need to pass pageIndex or will default be assumed?
+  // TODO: Verify if this works after pulling Redux search changes
+  return (
+    <li className="list-group-item">
+      <Link
+        className="search-item-link"
+        onClick={onItemSelect}
+        to={`/search?searchTerm=${searchTerm}&selectedTab=${resourceType}&pageIndex=0`}
+      >
+        <img className="icon icon-search" />
+        <div className="title-2 search-item-info">
+          <div className="search-term">{`${searchTerm}\u00a0`}</div>
+          <div className="search-item-text">{listItemText}</div>
+        </div>
+      </Link>
+    </li>
+  );
+};
+
+export default SearchItem;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResourceSearchList/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResourceSearchList/index.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { indexUsersEnabled } from 'config/config-utils';
+import { ResourceType } from 'interfaces';
+
+import SearchItem from './SearchItem';
+
+import * as CONSTANTS from '../constants';
+
+export interface ResourceSearchListProps {
+  onItemSelect: (event: Event) => void;
+  searchTerm: string;
+}
+
+class ResourceSearchList extends React.Component<ResourceSearchListProps, {}> {
+  constructor(props) {
+    super(props);
+  }
+
+  getListItemText = (resourceType: ResourceType): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        return CONSTANTS.DATASETS_ITEM_TEXT;
+      case ResourceType.user:
+        return CONSTANTS.PEOPLE_ITEM_TEXT;
+      default:
+        return '';
+    }
+  }
+
+  render = () => {
+    return (
+      <ul className="list-group">
+        <SearchItem
+          listItemText={this.getListItemText(ResourceType.table)}
+          onItemSelect={this.props.onItemSelect}
+          searchTerm={this.props.searchTerm}
+          resourceType={ResourceType.table}
+        />
+        {
+          indexUsersEnabled() &&
+          <SearchItem
+            listItemText={this.getListItemText(ResourceType.user)}
+            onItemSelect={this.props.onItemSelect}
+            searchTerm={this.props.searchTerm}
+            resourceType={ResourceType.user}
+          />
+        }
+      </ul>
+    );
+  }
+}
+
+export default ResourceSearchList;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResultsSuggestList/ResultItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResultsSuggestList/ResultItem/index.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface ResultItemProps {
+  href: string
+  iconClass: string;
+  onItemSelect: (event: Event) => void;
+  subtitle: string;
+  title: string;
+  type: string;
+}
+
+const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, onItemSelect, subtitle, title, type }) => {
+  return (
+    <li className="list-group-item">
+      <Link className="result-item-link" onClick={onItemSelect} to={ href }>
+        <img className={`result-icon ${iconClass}`} />
+
+        <div className="result-info">
+          <div className="truncated">
+            <div className="title-2 truncated">{ title }</div>
+            <div className="body-secondary-3 truncated">{ subtitle }</div>
+          </div>
+        </div>
+
+        <div className="resource-type">{ type }</div>
+      </Link>
+    </li>
+  );
+};
+
+export default ResultItem;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResultsSuggestList/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/ResultsSuggestList/index.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { ResourceType } from 'interfaces';
+
+import { SuggestedResult } from '../../SearchSuggest'
+import ResultItem from './ResultItem';
+
+export interface ResultsSuggestListProps {
+  onItemSelect: (event: Event) => void;
+  resourceType: string;
+  searchTerm: string;
+  suggestedResults: SuggestedResult[];
+  title: string;
+  totalResults: number;
+}
+
+class ResultsSuggestList extends React.Component<ResultsSuggestListProps, {}> {
+  constructor(props) {
+    super(props);
+  }
+
+  renderResultItems = (results: SuggestedResult[]) => {
+    return results.map((item, index) => {
+      const { href, iconClass, subtitle, title, type } = item;
+      return (
+        <ResultItem
+          key={`${this.props.resourceType}:${index}`}
+          href={href}
+          onItemSelect={this.props.onItemSelect}
+          iconClass={`icon ${iconClass}`}
+          subtitle={subtitle}
+          title={title}
+          type={type}
+        />
+      )
+    });
+  }
+
+  render = () => {
+    const { onItemSelect, resourceType, searchTerm, suggestedResults, totalResults, title } = this.props;
+    return (
+      <>
+        <div className="section-title title-3">{title}</div>
+        <ul className="list-group">
+          { this.renderResultItems(suggestedResults) }
+        </ul>
+        <Link
+          className="section-footer title-3"
+          onClick={onItemSelect}
+          to={`/search?searchTerm=${searchTerm}&selectedTab=${resourceType}&pageIndex=0`}
+        >
+          {/* TODO: Will I need to pass pageIndex or will default be assumed?
+              TODO: Verify if this works after pulling Redux search changes*/}
+          {`See all ${totalResults} ${title} results`}
+        </Link>
+      </>
+    );
+  }
+}
+
+export default ResultsSuggestList;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/constants.ts
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/constants.ts
@@ -1,0 +1,5 @@
+export const DATASETS = "Datasets";
+export const DATASETS_ITEM_TEXT = `in ${DATASETS}`;
+
+export const PEOPLE = "People";
+export const PEOPLE_ITEM_TEXT = `in ${PEOPLE}`;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/index.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import ResourceSearchList from './ResourceSearchList';
+import ResultsSuggestList from './ResultsSuggestList';
+
+import { indexUsersEnabled } from 'config/config-utils';
+import { ResourceType } from 'interfaces';
+
+import './styles.scss';
+
+import * as CONSTANTS from './constants';
+
+export interface SearchSuggestProps {
+  onItemSelect: (event: Event) => void;
+  searchTerm: string;
+  suggestedResults: {[id: string] : {results: SuggestedResult[], totalResults: number}};
+}
+
+export interface SuggestedResult {
+  href: string;
+  iconClass: string;
+  subtitle: string;
+  title: string;
+  type: string;
+}
+
+class SearchSuggest extends React.Component<SearchSuggestProps, {}> {
+  constructor(props) {
+    super(props);
+  }
+
+  getSuggestListTitle = (resourceType: ResourceType): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        return CONSTANTS.DATASETS;
+      case ResourceType.user:
+        return CONSTANTS.PEOPLE;
+      default:
+        return '';
+    }
+  }
+
+  render() {
+    return (
+      <div id="search-suggest" className="search-suggest">
+        <div className="search-suggest-section">
+          <ResourceSearchList
+            onItemSelect={this.props.onItemSelect}
+            searchTerm={this.props.searchTerm}
+          />
+        </div>
+        <div className="search-suggest-section">
+          <ResultsSuggestList
+            onItemSelect={this.props.onItemSelect}
+            resourceType={ResourceType.table}
+            searchTerm={this.props.searchTerm}
+            suggestedResults={this.props.suggestedResults[ResourceType.table].results}
+            totalResults={this.props.suggestedResults[ResourceType.table].totalResults}
+            title={this.getSuggestListTitle(ResourceType.table)}
+          />
+        </div>
+        {
+          indexUsersEnabled() &&
+          <div className="search-suggest-section">
+            <ResultsSuggestList
+              onItemSelect={this.props.onItemSelect}
+              resourceType={ResourceType.user}
+              searchTerm={this.props.searchTerm}
+              suggestedResults={this.props.suggestedResults[ResourceType.user].results}
+              totalResults={this.props.suggestedResults[ResourceType.user].totalResults}
+              title={this.getSuggestListTitle(ResourceType.user)}
+            />
+          </div>
+        }
+      </div>
+    );
+  }
+}
+
+export default SearchSuggest;

--- a/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/styles.scss
+++ b/amundsen_application/static/js/components/common/SearchBar/SearchSuggest/styles.scss
@@ -1,0 +1,98 @@
+@import 'variables';
+
+.search-suggest {
+  background: white;
+  width: 100%;
+  z-index: 10; // T__T
+  position: absolute;
+
+  border-radius: 4px;
+  border: 1px solid $gray-light;
+  box-shadow: 0 3px 12px 0 rgba(17, 17, 31, 0.04);
+
+  .search-suggest-section {
+    padding-top: 8px;
+    padding-bottom: 8px;
+
+    &:not(:first-of-type) {
+      border-top: 1px solid $gray-light;
+    }
+
+    .section-title {
+      margin-left: 16px;
+    }
+
+    .section-footer {
+      text-decoration: none;
+      color: $call-to-action-color !important; // TODO: temp color variable
+      margin-left: 16px;
+    }
+
+    .list-group {
+      margin: 0;
+
+      .list-group-item {
+        /* Override some shared list-group-item styles */
+        border: none;
+        &:hover {
+          box-shadow: none !important;
+          background-color: #EBEBFF; // TODO: temp color indigo5
+        }
+        &:hover + .list-group-item {
+          box-shadow: none !important;
+        }
+
+        .result-item-link,
+        .search-item-link {
+          color: $text-dark;
+          display: flex;
+          flex-direction: row;
+          text-decoration: none;
+
+          img.icon.icon-search,
+          img.icon.result-icon,
+          .sb-avatar {
+            margin: auto 8px auto 0px;
+          }
+        }
+
+        /* SEARCH ITEM */
+        .search-item-link {
+          height: 32px;
+          padding: 4px 4px 4px 24px;
+          &:hover {
+            .search-item-info .search-item-text {
+              font-weight: $font-weight-body-bold;
+            }
+          }
+          .search-item-info {
+            display: flex;
+            .search-item-text {
+              font-weight: $font-weight-body-regular;
+            }
+          }
+        }
+
+        /* RESULT ITEM */
+        .result-item-link {
+          height: 56px;
+          padding: 8px 8px 8px 24px;
+          .result-info {
+            display: flex;
+            flex: 1;
+            min-width: 0px;
+            margin-right: 8px;
+          }
+          .resource-type {
+            margin-top: auto;
+          }
+        }
+      }
+    }
+  }
+
+  /*&.small .result-item-link,
+  &.small .search-item-link {
+    padding-left: 10px !important;
+  }*/
+}

--- a/amundsen_application/static/js/components/common/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/index.tsx
@@ -1,6 +1,20 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { RouteComponentProps, withRouter } from 'react-router';
+
+import { searchAll } from 'ducks/search/reducer';
+import {
+  SearchAllRequest,
+  TableSearchResults,
+  UserSearchResults,
+} from 'ducks/search/types';
+import { GlobalState } from 'ducks/rootReducer';
+
+import { Resource, ResourceType, TableResource, UserResource } from 'interfaces';
+
+import SearchSuggest from './SearchSuggest';
+import { getDatabaseDisplayName, getDatabaseIconClass } from 'config/config-utils';
 
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
@@ -15,10 +29,16 @@ import {
   SYNTAX_ERROR_PREFIX,
   SYNTAX_ERROR_SPACING_SUFFIX,
 } from './constants';
-import { GlobalState } from 'ducks/rootReducer';
 
 export interface StateFromProps {
   searchTerm: string;
+  tables: TableSearchResults;
+  users: UserSearchResults;
+}
+
+export interface DispatchFromProps {
+  // TODO: Won't need selectedTab or pageIndex?
+  onInputChange: (term: string, selectedTab: ResourceType, pageIndex: number) => SearchAllRequest;
 }
 
 export interface OwnProps {
@@ -27,15 +47,18 @@ export interface OwnProps {
   size?: string;
 }
 
-export type SearchBarProps = StateFromProps & OwnProps & RouteComponentProps<any>;
+export type SearchBarProps = StateFromProps & DispatchFromProps & OwnProps & RouteComponentProps<any>;
 
 interface SearchBarState {
+  showTypeAhead: boolean;
   subTextClassName: string;
   searchTerm: string;
   subText: string;
 }
-
+// TODO: Close the typeahead when selecting an option
 export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
+  private refToSelf: React.RefObject<HTMLDivElement>;
+
   public static defaultProps: Partial<SearchBarProps> = {
     placeholder: PLACEHOLDER_DEFAULT,
     subText: SUBTEXT_DEFAULT,
@@ -44,25 +67,56 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
 
   constructor(props) {
     super(props);
+    this.refToSelf = React.createRef<HTMLDivElement>();
 
     this.state = {
+      showTypeAhead: false,
       subTextClassName: '',
       searchTerm: this.props.searchTerm,
       subText: this.props.subText,
     };
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const { searchTerm } = props;
-    return { searchTerm };
+  componentWillMount = () => {
+    document.addEventListener('mousedown', this.updateTypeAhead, false);
   }
 
-  clearSearchTerm = (event: React.SyntheticEvent<HTMLButtonElement>) : void => {
-    this.setState({ searchTerm: '' });
+  componentWillUnmount = () => {
+    document.removeEventListener('mousedown', this.updateTypeAhead, false);
+  }
+
+  shouldShowTypeAhead = (searchTerm: string) : boolean => {
+    return searchTerm.length > 0;
+  }
+
+  updateTypeAhead = (event: Event): void => {
+    if (this.refToSelf.current.contains(event.target as Node)) {
+      this.setState({ showTypeAhead: this.shouldShowTypeAhead(this.state.searchTerm) });
+    } else {
+      this.setState({ showTypeAhead: false });
+    }
   };
 
+  clearSearchTerm = (event: React.SyntheticEvent<HTMLButtonElement>) : void => {
+    this.setState({ showTypeAhead: false, searchTerm: '' });
+  };
+
+  onTypeAheadSelect = (event: Event) : void => {
+    this.setState({showTypeAhead: false});
+  }
+
   handleValueChange = (event: React.SyntheticEvent<HTMLInputElement>) : void => {
-    this.setState({ searchTerm: (event.target as HTMLInputElement).value.toLowerCase() });
+    const searchTerm = (event.target as HTMLInputElement).value.toLowerCase();
+    const showTypeAhead = this.shouldShowTypeAhead(searchTerm);
+    this.setState({ searchTerm, showTypeAhead });
+
+    if (showTypeAhead) {
+      /* TODO: Needs Redux work. To prevent the SearchPage from updating for
+         intermediate calls. Consider dispatching an action of another name that will
+         call search and control an `isIntermediate` boolean flag on the search state
+         or manage `intermediateResults` arrays on the search state. */
+      this.props.onInputChange(searchTerm, ResourceType.table, 0);
+    }
   };
 
   handleValueSubmit = (event: React.FormEvent<HTMLFormElement>) : void => {
@@ -102,13 +156,99 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     return true;
   };
 
+  mapResourcesToSuggestedResult = (resourceType: ResourceType, results: Resource[]) => {
+    return results.map((result) => {
+      return {
+        href: this.getSuggestedResultHref(resourceType, result),
+        iconClass: this.getSuggestedResultIconClass(resourceType, result),
+        subtitle: this.getSuggestedResultSubTitle(resourceType, result),
+        title: this.getSuggestedResultTitle(resourceType, result),
+        type: this.getSuggestedResultType(resourceType, result)
+      }
+    });
+  };
+
+  getSuggestedResultHref = (resourceType: ResourceType, result: Resource): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        const table = result as TableResource;
+        return `/table_detail/${table.cluster}/${table.database}/${table.schema_name}/${table.name}`;
+      case ResourceType.user:
+        const user = result as UserResource;
+        return `/user/${user.user_id}`;
+      default:
+        return '';
+    }
+  };
+
+  getSuggestedResultIconClass = (resourceType: ResourceType, result: Resource): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        const table = result as TableResource;
+        return getDatabaseIconClass(table.database);
+      case ResourceType.user:
+        return 'icon-users';
+      default:
+        return '';
+    }
+  };
+
+  getSuggestedResultSubTitle = (resourceType: ResourceType, result: Resource): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        const table = result as TableResource;
+        return table.description;
+      case ResourceType.user:
+        const user = result as UserResource;
+        // TODO: Display role_name and location when support exists
+        return user.team_name;
+      default:
+        return '';
+    }
+  };
+
+  getSuggestedResultTitle = (resourceType: ResourceType, result: Resource): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        const table = result as TableResource;
+        return `${table.schema_name}.${table.name}`;
+      case ResourceType.user:
+        const user = result as UserResource;
+        return user.display_name;
+      default:
+        return '';
+    }
+  };
+
+  getSuggestedResultType = (resourceType: ResourceType, result: Resource): string => {
+    switch (resourceType) {
+      case ResourceType.table:
+        const table = result as TableResource;
+        return getDatabaseDisplayName(table.database);
+      case ResourceType.user:
+        return 'User';
+      default:
+        return '';
+    }
+  };
+
   render() {
     const inputClass = `${this.props.size === SIZE_SMALL ? 'h3 small' : 'h2 large'} search-bar-input form-control`;
     const searchButtonClass = `btn btn-flat-icon search-button ${this.props.size === SIZE_SMALL ? 'small' : 'large'}`;
     const subTextClass = `subtext body-secondary-3 ${this.state.subTextClassName}`;
 
+    const suggestedResults = {
+      [ResourceType.table]: {
+        results: this.mapResourcesToSuggestedResult(ResourceType.table, this.props.tables.results.slice(0, 2)),
+        totalResults: this.props.tables.total_results,
+      },
+      [ResourceType.user]: {
+        results: this.mapResourcesToSuggestedResult(ResourceType.user, this.props.users.results.slice(0, 2)),
+        totalResults: this.props.users.total_results,
+      }
+    };
     return (
-      <div id="search-bar">
+      <div id="search-bar" ref={this.refToSelf}>
         <form className="search-bar-form" onSubmit={ this.handleValueSubmit }>
             <input
               id="search-input"
@@ -118,6 +258,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
               aria-label={ this.props.placeholder }
               placeholder={ this.props.placeholder }
               autoFocus={ true }
+              autoComplete="off"
             />
           <button className={ searchButtonClass } type="submit">
             <img className="icon icon-search" />
@@ -127,6 +268,14 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
             <button type="button" className="btn btn-close clear-button" aria-label={BUTTON_CLOSE_TEXT} onClick={this.clearSearchTerm} />
           }
         </form>
+        {
+          this.state.showTypeAhead &&
+          <SearchSuggest
+            onItemSelect={this.onTypeAheadSelect}
+            searchTerm={this.state.searchTerm}
+            suggestedResults={suggestedResults}
+          />
+        }
         {
           this.props.size !== SIZE_SMALL &&
           <div className={ subTextClass }>
@@ -141,7 +290,13 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
 export const mapStateToProps = (state: GlobalState) => {
   return {
     searchTerm: state.search.search_term,
+    tables: state.search.tables,
+    users: state.search.users,
   };
 };
 
-export default connect<StateFromProps, {}, OwnProps>(mapStateToProps, null)(withRouter(SearchBar));
+export const mapDispatchToProps = (dispatch: any) => {
+  return bindActionCreators({ onInputChange: searchAll }, dispatch);
+};
+
+export default connect<StateFromProps, DispatchFromProps, OwnProps>(mapStateToProps,  mapDispatchToProps)(withRouter(SearchBar));

--- a/amundsen_application/static/js/components/common/SearchBar/styles.scss
+++ b/amundsen_application/static/js/components/common/SearchBar/styles.scss
@@ -1,6 +1,8 @@
 @import 'variables';
 
 #search-bar {
+  position: relative;
+
   .search-bar-form {
     position: relative;
 

--- a/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
@@ -1,4 +1,4 @@
-/*import * as React from 'react';
+import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
@@ -21,7 +21,10 @@ describe('SearchBar', () => {
   const historyPushSpy = jest.spyOn(routerProps.history, 'push');
   const setup = (propOverrides?: Partial<SearchBarProps>) => {
     const props: SearchBarProps = {
+      onInputChange: jest.fn(),
       searchTerm: '',
+      tables: globalState.search.tables,
+      users: globalState.search.users,
       ...routerProps,
       ...propOverrides
     };
@@ -45,7 +48,7 @@ describe('SearchBar', () => {
     });
   });
 
-  describe('getDerivedStateFromProps', () => {
+  /*describe('getDerivedStateFromProps', () => {
     it('sets searchTerm on state from props', () => {
       const { props, wrapper } = setup();
       const prevState = wrapper.state();
@@ -56,16 +59,16 @@ describe('SearchBar', () => {
         searchTerm: 'newTerm',
       });
     });
-  });
+  });*/
 
-  describe('handleValueChange', () => {
+  /*describe('handleValueChange', () => {
     it('calls setState on searchTerm with event.target.value.toLowerCase()', () => {
       const { props, wrapper } = setup();
       // @ts-ignore: mocked events throw type errors
       wrapper.instance().handleValueChange(valueChangeMockEvent);
       expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: valueChangeMockEvent.target.value.toLowerCase() });
     });
-  });
+  });*/
 
   describe('handleValueSubmit', () => {
     let props;
@@ -165,7 +168,7 @@ describe('SearchBar', () => {
     });
   });
 
-  describe('render', () => {
+  /*describe('render', () => {
     let props;
     let wrapper;
     beforeAll(() => {
@@ -234,10 +237,10 @@ describe('SearchBar', () => {
         expect(wrapper.children().at(1).text()).toEqual(wrapper.state().subText);
       });
     });
-  });
+  });*/
 });
 
-describe('mapStateToProps', () => {
+/*describe('mapStateToProps', () => {
   let result;
   beforeAll(() => {
     result = mapStateToProps(globalState);

--- a/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+/*import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
@@ -246,4 +246,4 @@ describe('mapStateToProps', () => {
   it('sets searchTerm on the props', () => {
     expect(result.searchTerm).toEqual(globalState.search.search_term);
   });
-});
+});*/

--- a/amundsen_application/static/js/config/config-utils.ts
+++ b/amundsen_application/static/js/config/config-utils.ts
@@ -30,3 +30,7 @@ export function getDatabaseIconClass(databaseId: string): string {
 
   return databaseConfig.iconClass;
 }
+
+export function indexUsersEnabled(): boolean {
+  return AppConfig.indexUsers.enabled;
+}

--- a/amundsen_application/static/js/ducks/search/sagas.ts
+++ b/amundsen_application/static/js/ducks/search/sagas.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { all, call, put, takeEvery } from 'redux-saga/effects';
+import { all, call, put, takeEvery, takeLatest } from 'redux-saga/effects';
 
 import { ResourceType } from 'interfaces/Resources';
 
@@ -42,7 +42,7 @@ export function* searchAllWorker(action: SearchAllRequest): SagaIterator {
   }
 };
 export function* searchAllWatcher(): SagaIterator {
-  yield takeEvery(SearchAll.REQUEST, searchAllWorker);
+  yield takeLatest(SearchAll.REQUEST, searchAllWorker);
 };
 
 export function* searchResourceWorker(action: SearchResourceRequest): SagaIterator {

--- a/amundsen_application/static/js/ducks/search/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/search/tests/index.spec.ts
@@ -207,7 +207,7 @@ describe('search ducks', () => {
     describe('searchAllWatcher', () => {
       it('takes every SearchAll.REQUEST with searchAllWorker', () => {
         testSaga(searchAllWatcher)
-          .next().takeEvery(SearchAll.REQUEST, searchAllWorker)
+          .next().takeLatest(SearchAll.REQUEST, searchAllWorker)
           .next().isDone();
       });
     });


### PR DESCRIPTION
### Summary of Changes
This PR implements our "typeahead"/"autosuggest" feature, as defined by our mocks in our redsign [roadmap item](https://github.com/lyft/amundsen/blob/master/docs/roadmap.md#search--resource-page-redesign).
![image](https://user-images.githubusercontent.com/1790900/63624213-94a0e880-c5b0-11e9-9041-985499914e66.png)


#### SearchBar
1. The `SearchBar` dispatches a search request on every inputChange, and has the results mapped to its state. In the Reducx layer, only the latest search request is allowed to complete.
2. The `SearchBar` is set up to render a `SearchSuggest` component and has new logic regarding show to show/hide the component. It will be shown as long as the user is interacting with the `SearchBar` and the searchTerm is not empty.
3. The `SearchBar` passes the top search results and total count to `SearchSuggest`. `SearchSuggest` then uses that information to populate it's content.
**TODO: In order to stop the SearchPage from refreshing if using this feature on that page, more work has to be done in the redux layer after pull changes from https://github.com/lyft/amundsenfrontendlibrary/pull/265**

#### SearchSuggest  (_naming suggestions welcome for new components_)
1. Renders a `ResourceSearchList ` which takes the current `searchTerm` and renders a list of `SearchItem`s for each enabled resource. When clicked each `SearchItem` takes the user to the first page of results for the given resource and searchTerm. 
    ![image](https://user-images.githubusercontent.com/1790900/63624735-4a206b80-c5b2-11e9-8f38-d171ab398a26.png)
    **TODO: Verify that this works with the new Redux changes**
2. Renders a `ResultsSuggestList ` for each resource. This component is passed the information it needs to render a section as depicted below, with a `ResultItem` for each of the top 2 search results. `ResultItem` can be reused for each resource type as the format and layout is the same. 
    ![image](https://user-images.githubusercontent.com/1790900/63624771-68866700-c5b2-11e9-85d8-a796c1d6e7bb.png)
3. When navigating to a new page after a click, the `SearchSuggest` closes due to a callback passed all the way to the `<Link>` `onClick` method.

#### NavBar
1. Some NavBar styles renested as to not have any effect on the SearchBar, only on the `.nav-bar-left` and `.nav-bar-right` content.

#### Miscellaneous
1. Added a utility method for knowing if we will render “People” related user interfaces.
2. The exact typography needs, color specifications, and spacing for this design was not as fully fleshed out in Abstract. Some tweaks may be needed after presenting this in a Design sync.

### Tests

**TODO: Tests will be modified and added based on component changes**

### Documentation

N/A. This feature does not currently require any new documentation.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
