### PR TITLE
Preserve compatibility in base_mail_client

### DIFF
--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -56,7 +56,7 @@ def feedback() -> Response:
             'form_data': data
         }
 
-        response = mail_client.send_email(subject=subject, text=text_content, html=html_content, options=options)
+        response = mail_client.send_email(subject=subject, text=text_content, html=html_content, optional_data=options)
         status_code = response.status_code
 
         if status_code == HTTPStatus.OK:

--- a/amundsen_application/api/utils/notification_utils.py
+++ b/amundsen_application/api/utils/notification_utils.py
@@ -57,7 +57,7 @@ def send_notification(*, notification_type: str, options: Dict, recipients: List
             sender=sender,
             subject=notification_content['subject'],
             html=notification_content['html'],
-            options={
+            optional_data={
                 'email_type': 'notification'
             },
         )

--- a/amundsen_application/base/base_mail_client.py
+++ b/amundsen_application/base/base_mail_client.py
@@ -16,7 +16,7 @@ class BaseMailClient(abc.ABC):
                    subject: str,
                    text: str,
                    html: str,
-                   options: Dict) -> Response:
+                   optional_data: Dict) -> Response:
         """
         Sends an email using the following parameters
         :param sender: The sending address associated with the email
@@ -24,7 +24,7 @@ class BaseMailClient(abc.ABC):
         :param subject: The subject of the email
         :param text: Plain text email content
         :param html: HTML email content
-        :param options: A dictionary of any values needed for custom implementations
+        :param optional_data: A dictionary of any values needed for custom implementations
         :return:
         """
         raise NotImplementedError  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-__version__ = '1.0.7'
+__version__ = '1.1.0'
 
 
 setup(

--- a/tests/unit/api/mail/test_v0.py
+++ b/tests/unit/api/mail/test_v0.py
@@ -21,7 +21,7 @@ class MockMailClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   options: Dict = {}) -> Response:
+                   optional_data: Dict = {}) -> Response:
         return make_response(jsonify({}), self.status_code)
 
 
@@ -35,7 +35,7 @@ class MockBadClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   options: Dict = {}) -> Response:
+                   optional_data: Dict = {}) -> Response:
         raise Exception('Bad client')
 
 

--- a/tests/unit/utils/notification/test_v0.py
+++ b/tests/unit/utils/notification/test_v0.py
@@ -25,7 +25,7 @@ class MockMailClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   options: Dict = {}) -> Response:
+                   optional_data: Dict = {}) -> Response:
         return make_response(jsonify({}), self.status_code)
 
 
@@ -195,7 +195,7 @@ class NotificationUtilsTest(unittest.TestCase):
                 sender=test_sender,
                 subject=mock_content['subject'],
                 html=mock_content['html'],
-                options={'email_type': 'notification'},
+                optional_data={'email_type': 'notification'},
             )
 
     def test_no_recipients_for_notification(self) -> None:


### PR DESCRIPTION
### Summary of Changes

The current backwards incompatibility in the notifications project is simply due to the change in the name of a parameter on `base_mail_client.send_email`.  The parameter `optional_data`, in hindsight would be better called `options`. However because the change creates a backwards incompatibility -- i.e. this change will break everyone's current implementations of the `base_mail_client` -- I propose we keep the parameter as `optional_data` and update it in the future when we have more reason to create a new major release.

This PR reverts use of `options` back to `optional_data`, and the notifications project can become a new minor release at `1.1.0`.

### Tests

Reverted use of `options` back to `optional_data`.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
