### PR TITLE
Added auto-select resource after searching

### DIFF
--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -32,7 +32,7 @@ export interface SearchReducerState {
 };
 
 /* ACTIONS */
-export function searchAll(term: string, resource: ResourceType, pageIndex: number): SearchAllRequest {
+export function searchAll(term: string, resource?: ResourceType, pageIndex?: number): SearchAllRequest {
   return {
     payload: {
       resource,

--- a/amundsen_application/static/js/ducks/search/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/search/tests/index.spec.ts
@@ -1,6 +1,6 @@
 import { testSaga } from 'redux-saga-test-plan';
 
-import { ResourceType } from 'interfaces';
+import { DEFAULT_RESOURCE_TYPE, ResourceType } from 'interfaces';
 
 import * as API from '../api/v0';
 
@@ -534,6 +534,52 @@ describe('search ducks', () => {
       it('returns 0 if not given a supported ResourceType', () => {
         // @ts-ignore: cover default case
         expect(SearchUtils.getPageIndex(mockState, 'not valid input')).toEqual(0);
+      });
+    });
+
+    describe('autoSelectResource', () => {
+      const emptyMockState = {
+        ...searchState,
+        dashboards: {
+          ...searchState.dashboards,
+          total_results: 0,
+        },
+        tables: {
+          ...searchState.tables,
+          total_results: 0,
+        },
+        users: {
+          ...searchState.users,
+          total_results: 0,
+        }
+      };
+
+      it('returns the DEFAULT_RESOURCE_TYPE when search results are empty', () => {
+        expect(SearchUtils.autoSelectResource(emptyMockState)).toEqual(DEFAULT_RESOURCE_TYPE);
+      });
+
+      it('prefers `table` over `user` and `dashboard`', () => {
+        const mockState = { ...emptyMockState };
+        mockState.tables.total_results = 10;
+        mockState.users.total_results = 10;
+        mockState.dashboards.total_results = 10;
+        expect(SearchUtils.autoSelectResource(mockState)).toEqual(ResourceType.table);
+      });
+
+      it('prefers `user` over `dashboard`', () => {
+        const mockState = { ...emptyMockState };
+        mockState.tables.total_results = 0;
+        mockState.users.total_results = 10;
+        mockState.dashboards.total_results = 10;
+        expect(SearchUtils.autoSelectResource(mockState)).toEqual(ResourceType.user);
+      });
+
+      it('returns `dashboard` if there are dashboards but no other results', () => {
+        const mockState = { ...emptyMockState };
+        mockState.tables.total_results = 0;
+        mockState.users.total_results = 0;
+        mockState.dashboards.total_results = 10;
+        expect(SearchUtils.autoSelectResource(mockState)).toEqual(ResourceType.dashboard);
       });
     });
   });

--- a/amundsen_application/static/js/ducks/search/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/search/tests/index.spec.ts
@@ -331,7 +331,7 @@ describe('search ducks', () => {
         const term = 'test';
         updateSearchUrlSpy.mockClear();
         testSaga(submitSearchWorker, submitSearch(term))
-          .next().put(searchAll(term, ResourceType.table, 0))
+          .next().put(searchAll(term))
           .next().isDone();
           expect(updateSearchUrlSpy).toHaveBeenCalledWith({ term });
 

--- a/amundsen_application/static/js/ducks/search/utils.ts
+++ b/amundsen_application/static/js/ducks/search/utils.ts
@@ -21,9 +21,11 @@ export const getPageIndex = (state: SearchReducerState, resource?: ResourceType)
 export const autoSelectResource = (state: SearchReducerState) => {
   if (state.tables && state.tables.total_results > 0) {
     return ResourceType.table;
-  } else if (state.users && state.users.total_results > 0) {
+  }
+  if (state.users && state.users.total_results > 0) {
     return ResourceType.user
-  } if (state.dashboards && state.dashboards.total_results > 0) {
+  }
+  if (state.dashboards && state.dashboards.total_results > 0) {
     return ResourceType.dashboard
   }
   return DEFAULT_RESOURCE_TYPE;

--- a/amundsen_application/static/js/ducks/search/utils.ts
+++ b/amundsen_application/static/js/ducks/search/utils.ts
@@ -1,6 +1,6 @@
 import { GlobalState } from 'ducks/rootReducer';
 import { SearchReducerState } from 'ducks/search/reducer';
-import { ResourceType } from 'interfaces/Resources';
+import { DEFAULT_RESOURCE_TYPE, ResourceType } from 'interfaces/Resources';
 
 export const getSearchState = (state: GlobalState): SearchReducerState => state.search;
 
@@ -15,4 +15,16 @@ export const getPageIndex = (state: SearchReducerState, resource?: ResourceType)
       return state.dashboards.page_index;
   };
   return 0;
+};
+
+
+export const autoSelectResource = (state: SearchReducerState) => {
+  if (state.tables && state.tables.total_results > 0) {
+    return ResourceType.table;
+  } else if (state.users && state.users.total_results > 0) {
+    return ResourceType.user
+  } if (state.dashboards && state.dashboards.total_results > 0) {
+    return ResourceType.dashboard
+  }
+  return DEFAULT_RESOURCE_TYPE;
 };

--- a/amundsen_application/static/js/interfaces/Resources.ts
+++ b/amundsen_application/static/js/interfaces/Resources.ts
@@ -6,6 +6,8 @@ export enum ResourceType {
   dashboard = "dashboard",
 };
 
+export const DEFAULT_RESOURCE_TYPE = ResourceType.table;
+
 export interface Resource {
   type: ResourceType;
 };


### PR DESCRIPTION
### Summary of Changes

Added functionality to auto-select a resource on search. This picks the first resource type with results (table -> user -> dashboard). If there are no results, a default (table) is selected.

### Tests
Added tests for the auto-select utility function.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
