### PR TITLE
Relative URLs to child configuration docs

### DIFF
--- a/docs/application_config.md
+++ b/docs/application_config.md
@@ -25,7 +25,7 @@ As these are optional features, our `MailClientFeaturesConfig` can be used to hi
 2. Set `MailClientFeaturesConfig.notificationsEnabled` to `true` in order to display the optional UI for users to request more information about resources on the `TableDetail` page.
 
 For information about how to configure a custom mail
-client, please see this [entry](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/flask_config.md#mail-client-features) in our flask configuration doc.
+client, please see this [entry](flask_config.md#mail-client-features) in our flask configuration doc.
 
 ## Navigation Links
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 ## Flask
 The default Flask application uses a [LocalConfig](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/config.py) that looks for the metadata and search services running on localhost. In order to use different end point, you need to create a custom config class suitable for your use case. Once the config class has been created, it can be referenced via the [environment variable](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/wsgi.py#L5): `FRONTEND_SVC_CONFIG_MODULE_CLASS`
 
-For more examples of how to leverage the Flask configuration for specific features, please see this [extended doc](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/flask_config.md).
+For more examples of how to leverage the Flask configuration for specific features, please see this [extended doc](flask_config.md).
 
 For more information on Flask configurations, please reference the official Flask [documentation](http://flask.pocoo.org/docs/1.0/config/#development-production).
 
@@ -12,7 +12,7 @@ For more information on Flask configurations, please reference the official Flas
 ### Application Config
 Certain features of the React application import variables from an [AppConfig](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/js/config/config.ts#L5) object. The configuration can be customized by modifying [config-custom.ts](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/js/config/config-custom.ts).
 
-For examples of how to leverage the application configuration for specific features, please see this [extended doc](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/application_config.md).
+For examples of how to leverage the application configuration for specific features, please see this [extended doc](application_config.md).
 
 ### Custom Fonts & Styles
 Fonts and css variables can be customized by modifying [fonts-custom.scss](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/static/css/_fonts-custom.scss) and

--- a/docs/flask_config.md
+++ b/docs/flask_config.md
@@ -7,4 +7,4 @@ After modifying any variable in [config.py](https://github.com/lyft/amundsenfron
 ## Mail Client Features
 Amundsen has two features that leverage the custom mail client -- the feedback tool and notifications. For these features a custom implementation of [base_mail_client](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/base/base_mail_client.py) must be mapped to the `MAIL_CLIENT` configuration variable.
 
-To fully enable these features in the UI, the application configuration variables for these features must also be set to true. Please see this [entry](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/application_config.md#mail-client-features) in our application configuration doc for further information.
+To fully enable these features in the UI, the application configuration variables for these features must also be set to true. Please see this [entry](application_config.md#mail-client-features) in our application configuration doc for further information.


### PR DESCRIPTION


### Summary of Changes

Relative URLs to docs in the same folder should do. They work for any branch, local copies of the docs - and should work better if we ever (or whenever :-) we get to having e.g a Sphinx generated site.

### Tests

Manual GH markdown diff inspection



### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)