### PR TITLE
Improve behavior of notification sending for owner editing

### DIFF
--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -93,14 +93,24 @@ def notification() -> Response:
     """
     try:
         data = request.get_json()
+
+        notification_type = data.get('notificationType')
+        if notification_type is None:
+            message = 'Encountered exception: notificationType must be provided in the request payload'
+            logging.exception(message)
+            return make_response(jsonify({'msg': message}), HTTPStatus.BAD_REQUEST)
+
         sender = data.get('sender')
         if sender is None:
             sender = app.config['AUTH_USER_METHOD'](app).email
 
+        options = data.get('options', {})
+        recipients = data.get('recipients', [])
+
         return send_notification(
-            notification_type=data['notificationType'],
-            options=data['options'],
-            recipients=data['recipients'],
+            notification_type=notification_type,
+            options=options,
+            recipients=recipients,
             sender=sender
         )
     except Exception as e:

--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -3,6 +3,7 @@ import logging
 from http import HTTPStatus
 
 from flask import Response, jsonify, make_response, render_template, request
+from flask import current_app as app
 from flask.blueprints import Blueprint
 
 from amundsen_application.api.exceptions import MailClientNotImplemented
@@ -92,11 +93,15 @@ def notification() -> Response:
     """
     try:
         data = request.get_json()
+        sender = data.get('sender')
+        if sender is None:
+            sender = app.config['AUTH_USER_METHOD'](app).email
+
         return send_notification(
             notification_type=data['notificationType'],
             options=data['options'],
             recipients=data['recipients'],
-            sender=data['sender']
+            sender=sender
         )
     except Exception as e:
         message = 'Encountered exception: ' + str(e)

--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -12,7 +12,6 @@ from amundsen_application.log.action_log import action_logging
 from amundsen_application.models.user import load_user, dump_user
 
 from amundsen_application.api.utils.metadata_utils import marshall_table_partial, marshall_table_full
-from amundsen_application.api.utils.notification_utils import send_notification, table_key_to_url
 from amundsen_application.api.utils.request_utils import get_query_param, request_metadata
 
 
@@ -147,29 +146,12 @@ def update_table_owner() -> Response:
         pass  # pragma: no cover
 
     try:
-        user = app.config['AUTH_USER_METHOD'](app)
         args = request.get_json()
         table_key = get_query_param(args, 'key')
-        resource_name = get_query_param(args, 'name')
         owner = get_query_param(args, 'owner')
 
-        notification_type = None
-        if request.method == 'PUT':
-            notification_type = 'added'
-        elif request.method == 'DELETE':
-            notification_type = 'removed'
-        else:
-            raise Exception('method not handled')
-
-        send_notification(
-            notification_type=notification_type,
-            options={
-                'resource_name': resource_name,
-                'resource_url': table_key_to_url(table_key=table_key)
-            },
-            recipients=[owner],
-            sender=user.email
-        )
+        if owner == 'test_fail':
+            return make_response(jsonify({'msg': 'This is a test failure'}), HTTPStatus.INTERNAL_SERVER_ERROR)
 
         table_endpoint = _get_table_endpoint()
         url = '{0}/{1}/owner/{2}'.format(table_endpoint, table_key, owner)

--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -150,9 +150,6 @@ def update_table_owner() -> Response:
         table_key = get_query_param(args, 'key')
         owner = get_query_param(args, 'owner')
 
-        if owner == 'test_fail':
-            return make_response(jsonify({'msg': 'This is a test failure'}), HTTPStatus.INTERNAL_SERVER_ERROR)
-
         table_endpoint = _get_table_endpoint()
         url = '{0}/{1}/owner/{2}'.format(table_endpoint, table_key, owner)
         method = request.method

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -8,7 +8,7 @@ import serialize from 'form-serialize';
 import AvatarLabel, { AvatarLabelProps } from 'components/common/AvatarLabel';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 import { Modal } from 'react-bootstrap';
-import { UpdateMethod } from 'interfaces';
+import { UpdateMethod, UpdateOwnerPayload } from 'interfaces';
 
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
@@ -19,7 +19,7 @@ import { GlobalState } from 'ducks/rootReducer';
 import { updateTableOwner } from 'ducks/tableMetadata/owners/reducer';
 
 export interface DispatchFromProps {
-  onUpdateList: (updateArray: { method: UpdateMethod; id: string; }[], onSuccess?: () => any, onFailure?: () => any) => void;
+  onUpdateList: (updateArray: UpdateOwnerPayload[], onSuccess?: () => any, onFailure?: () => any) => void;
 }
 
 export interface ComponentProps {

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -1,8 +1,8 @@
 import * as qs from 'simple-query-string';
 
 import { filterFromObj, sortTagsAlphabetical } from 'ducks/utilMethods';
-
-import { OwnerDict, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
+import { globalState } from 'fixtures';
+import { OwnerDict, PeopleUser, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
 import * as API from './v0';
 
 /**
@@ -65,3 +65,10 @@ export function createOwnerUpdatePayload(payload: UpdateOwnerPayload, tableKey: 
     },
   }
 };
+
+/**
+ * Workaround logic for not sending emails to alumni or teams.
+ */
+export function shouldSendNotification(user: PeopleUser): boolean {
+  return user.is_active && !!user.display_name;
+}

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -2,7 +2,7 @@ import * as qs from 'simple-query-string';
 
 import { filterFromObj, sortTagsAlphabetical } from 'ducks/utilMethods';
 
-import { OwnerDict, PeopleUser, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
+import { NotificationType, OwnerDict, PeopleUser, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
 import * as API from './v0';
 
 /**
@@ -43,7 +43,7 @@ export function getTableTagsFromResponseData(responseData: API.TableDataAPI): Ta
  */
 export function createOwnerNotificationData(payload: UpdateOwnerPayload, resourceName: string) {
   return {
-    notificationType: payload.method === UpdateMethod.PUT ? 'added' : 'removed',
+    notificationType: payload.method === UpdateMethod.PUT ? NotificationType.ADDED : NotificationType.REMOVED,
     options: {
       resource_name: resourceName,
       resource_url: window.location.href,

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -2,7 +2,7 @@ import * as qs from 'simple-query-string';
 
 import { filterFromObj, sortTagsAlphabetical } from 'ducks/utilMethods';
 
-import { OwnerDict, TableMetadata, Tag, User } from 'interfaces';
+import { OwnerDict, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
 import * as API from './v0';
 
 /**
@@ -37,3 +37,31 @@ export function getTableOwnersFromResponseData(responseData: API.TableDataAPI): 
 export function getTableTagsFromResponseData(responseData: API.TableDataAPI): Tag[] {
   return responseData.tableData.tags.sort(sortTagsAlphabetical);
 }
+
+/**
+ * Creates post data for sending a notification to owners when they are added/removed
+ */
+export function createOwnerNotificationData(payload: UpdateOwnerPayload, resourceName: string) {
+  return {
+    notificationType: payload.method === UpdateMethod.PUT ? 'added' : 'removed',
+    options: {
+      resource_name: resourceName,
+      resource_url: window.location.href,
+    },
+    recipients: [payload.id],
+  };
+};
+
+/**
+ * Creates axios payload for the request to update an owner
+ */
+export function createOwnerUpdatePayload(payload: UpdateOwnerPayload, tableKey: string) {
+  return {
+    method: payload.method,
+    url: `${API.API_PATH}/update_table_owner`,
+    data: {
+      key: tableKey,
+      owner: payload.id,
+    },
+  }
+};

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -1,7 +1,7 @@
 import * as qs from 'simple-query-string';
 
 import { filterFromObj, sortTagsAlphabetical } from 'ducks/utilMethods';
-import { globalState } from 'fixtures';
+
 import { OwnerDict, PeopleUser, TableMetadata, Tag, UpdateMethod, UpdateOwnerPayload, User } from 'interfaces';
 import * as API from './v0';
 

--- a/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
@@ -7,7 +7,7 @@ import * as Utils from 'ducks/utilMethods';
 
 import globalState from 'fixtures/globalState';
 
-import { UpdateMethod, UpdateOwnerPayload } from 'interfaces';
+import { NotificationType, UpdateMethod, UpdateOwnerPayload } from 'interfaces';
 
 import * as API from '../v0';
 
@@ -78,7 +78,7 @@ describe('helpers', () => {
       const testMethod = UpdateMethod.PUT;
       const testName = 'schema.tableName';
       expect(Helpers.createOwnerNotificationData({ method: testMethod, id: testId }, testName)).toMatchObject({
-        notificationType: 'added',
+        notificationType: NotificationType.ADDED,
         options: {
           resource_name: testName,
           resource_url: window.location.href,
@@ -92,7 +92,7 @@ describe('helpers', () => {
       const testMethod = UpdateMethod.DELETE;
       const testName = 'schema.tableName';
       expect(Helpers.createOwnerNotificationData({ method: testMethod, id: testId }, testName)).toMatchObject({
-        notificationType: 'removed',
+        notificationType: NotificationType.REMOVED,
         options: {
           resource_name: testName,
           resource_url: window.location.href,

--- a/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
@@ -115,4 +115,27 @@ describe('helpers', () => {
       },
     });
   });
+
+  describe('shouldSendNotification', () => {
+    it('returns false if alumni', () => {
+      const testUser = {
+        ... globalState.user.loggedInUser,
+        is_active: false,
+      }
+      expect(Helpers.shouldSendNotification(testUser)).toBe(false);
+    });
+
+    it('returns false if not a user with display_name', () => {
+      const testUser = {
+        ... globalState.user.loggedInUser,
+        display_name: null,
+      }
+      expect(Helpers.shouldSendNotification(testUser)).toBe(false);
+    });
+
+    it('returns true if user is_active and has a display_name', () => {
+      const testUser = { ... globalState.user.loggedInUser }
+      expect(Helpers.shouldSendNotification(testUser)).toBe(true);
+    });
+  });
 });

--- a/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/tests/index.spec.ts
@@ -7,6 +7,8 @@ import * as Utils from 'ducks/utilMethods';
 
 import globalState from 'fixtures/globalState';
 
+import { UpdateMethod, UpdateOwnerPayload } from 'interfaces';
+
 import * as API from '../v0';
 
 const filterFromObjSpy = jest.spyOn(Utils, 'filterFromObj').mockImplementation((initialObject, rejectedKeys) => { return initialObject; });
@@ -29,7 +31,7 @@ describe('helpers', () => {
   });
 
   describe('getTableQueryParams', () => {
-    it('generates table query params with a key',() => {
+    it('generates table query params with a key', () => {
       const tableKey = 'database://cluster.schema/table';
       const queryString = Helpers.getTableQueryParams(tableKey);
       const params = qs.parse(queryString);
@@ -39,7 +41,7 @@ describe('helpers', () => {
       expect(params.source).toEqual(undefined);
     });
 
-    it('generates query params with logging params',() => {
+    it('generates query params with logging params', () => {
       const tableKey = 'database://cluster.schema/table';
       const index = '4';
       const source = 'test-source';
@@ -52,21 +54,65 @@ describe('helpers', () => {
     });
   });
 
-  it('getTableDataFromResponseData',() => {
+  it('getTableDataFromResponseData', () => {
     Helpers.getTableDataFromResponseData(mockResponseData);
     expect(filterFromObjSpy).toHaveBeenCalledWith(tableResponseData, ['owners', 'tags']);
   });
 
-  it('getTableOwnersFromResponseData',() => {
+  it('getTableOwnersFromResponseData', () => {
     expect(Helpers.getTableOwnersFromResponseData(mockResponseData)).toEqual({
       'test': {display_name: 'test', profile_url: 'test.io', email: 'test@test.com', user_id: 'test'}
     });
   });
 
-  it('getTableTagsFromResponseData',() => {
+  it('getTableTagsFromResponseData', () => {
     expect(Helpers.getTableTagsFromResponseData(mockResponseData)).toEqual([
       {tag_count: 1, tag_name: 'aname'},
       {tag_count: 2, tag_name: 'zname'},
     ]);
+  });
+
+  describe('createOwnerNotificationData', () => {
+    it('creates correct request data for PUT', () => {
+      const testId =  'testId@test.com';
+      const testMethod = UpdateMethod.PUT;
+      const testName = 'schema.tableName';
+      expect(Helpers.createOwnerNotificationData({ method: testMethod, id: testId }, testName)).toMatchObject({
+        notificationType: 'added',
+        options: {
+          resource_name: testName,
+          resource_url: window.location.href,
+        },
+        recipients: [testId],
+      });
+    });
+
+    it('creates correct request data for DELETE', () => {
+      const testId =  'testId@test.com';
+      const testMethod = UpdateMethod.DELETE;
+      const testName = 'schema.tableName';
+      expect(Helpers.createOwnerNotificationData({ method: testMethod, id: testId }, testName)).toMatchObject({
+        notificationType: 'removed',
+        options: {
+          resource_name: testName,
+          resource_url: window.location.href,
+        },
+        recipients: [testId],
+      });
+    });
+  });
+
+  it('createOwnerUpdatePayload', () => {
+    const testId =  'testId@test.com';
+    const testKey = 'testKey';
+    const testMethod = UpdateMethod.PUT;
+    expect(Helpers.createOwnerUpdatePayload({ method: testMethod, id: testId }, testKey)).toMatchObject({
+      method: testMethod,
+      url: `${API.API_PATH}/update_table_owner`,
+      data: {
+        key: testKey,
+        owner: testId,
+      },
+    });
   });
 });

--- a/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -90,7 +90,7 @@ export function getTableOwners(tableKey: string) {
 
 /* TODO: Typing return type generates redux-saga related type error that need more dedicated debugging */
 export function generateOwnerUpdateRequests(updateArray: UpdateOwnerPayload[], tableKey: string, resourceName: string) {
-  let updateRequests = [];
+  const updateRequests = [];
 
   /* Create the request for updating each owner*/
   updateArray.forEach((item) => {

--- a/amundsen_application/static/js/ducks/tableMetadata/owners/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/owners/sagas.ts
@@ -12,7 +12,8 @@ export function* updateTableOwnerWorker(action: UpdateTableOwnerRequest): SagaIt
   const state = yield select();
   const tableData = state.tableMetadata.tableData;
   try {
-    yield all(API.updateTableOwner(payload.updateArray, tableData.key, `${tableData.schema}.${tableData.table_name}`));
+    const requestList = API.generateOwnerUpdateRequests(payload.updateArray, tableData.key, `${tableData.schema}.${tableData.table_name}`);
+    yield all(requestList);
     const newOwners = yield call(API.getTableOwners, tableData.key);
     yield put(updateTableOwnerSuccess(newOwners));
     if (payload.onSuccess) {

--- a/amundsen_application/static/js/ducks/tableMetadata/owners/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/owners/tests/index.spec.ts
@@ -16,7 +16,7 @@ import { updateTableOwnerWorker, updateTableOwnerWatcher } from '../sagas';
 
 import { GetTableData, UpdateTableOwner } from '../../types';
 
-const updateTableOwnerSpy = jest.spyOn(API, 'updateTableOwner').mockImplementation((payload, key) => []);
+const generateOwnerUpdateRequestsSpy = jest.spyOn(API, 'generateOwnerUpdateRequests').mockImplementation((payload, key) => []);
 
 describe('tableMetadata:owners ducks', () => {
   let expectedOwners: OwnerDict;
@@ -131,7 +131,7 @@ describe('tableMetadata:owners ducks', () => {
           sagaTest = (action) => {
             return testSaga(updateTableOwnerWorker, action)
                 .next().select()
-                .next(globalState).all(API.updateTableOwner(updatePayload, globalState.tableMetadata.tableData.key, globalState.tableMetadata.tableData.table_name))
+                .next(globalState).all(API.generateOwnerUpdateRequests(updatePayload, globalState.tableMetadata.tableData.key, globalState.tableMetadata.tableData.table_name))
                 .next().call(API.getTableOwners, globalState.tableMetadata.tableData.key)
                 .next(expectedOwners).put(updateTableOwnerSuccess(expectedOwners));
           };

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def build_js() -> None:
         logging.warn('Installation of npm dependencies failed')
         logging.warn(str(e))
 
+
 build_js()
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements3.txt')

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -329,64 +329,6 @@ class MetadataTest(unittest.TestCase):
             self.assertEqual(response.status_code, HTTPStatus.OK)
 
     @responses.activate
-    @unittest.mock.patch('amundsen_application.api.metadata.v0.send_notification')
-    def test_update_table_owner_send_notification_added(self, send_notification_mock) -> None:
-        """
-        Test update_table_owner with PUT calls send_notification
-        using the 'added' notification type
-        :return:
-        """
-        url = local_app.config['METADATASERVICE_BASE'] + TABLE_ENDPOINT + '/db://cluster.schema/table/owner/test'
-        responses.add(responses.PUT, url, json={}, status=HTTPStatus.OK)
-        with local_app.test_client() as test:
-            test.put(
-                '/api/metadata/v0/update_table_owner',
-                json={
-                    'key': 'db://cluster.schema/table',
-                    'owner': 'test',
-                    'name': 'schema.table'
-                }
-            )
-            send_notification_mock.assert_called_with(
-                notification_type='added',
-                options={
-                    'resource_name': 'schema.table',
-                    'resource_url': 'http://0.0.0.0:5000/table_detail/cluster/db/schema/table'
-                },
-                recipients=['test'],
-                sender=local_app.config['AUTH_USER_METHOD'](local_app).email
-            )
-
-    @responses.activate
-    @unittest.mock.patch('amundsen_application.api.metadata.v0.send_notification')
-    def test_update_table_owner_send_notification_deleted(self, send_notification_mock) -> None:
-        """
-        Test update_table_owner with DELETE calls send_notification
-        using the 'removed' notification type
-        :return:
-        """
-        url = local_app.config['METADATASERVICE_BASE'] + TABLE_ENDPOINT + '/db://cluster.schema/table/owner/test'
-        responses.add(responses.DELETE, url, json={}, status=HTTPStatus.OK)
-        with local_app.test_client() as test:
-            test.delete(
-                '/api/metadata/v0/update_table_owner',
-                json={
-                    'key': 'db://cluster.schema/table',
-                    'owner': 'test',
-                    'name': 'schema.table'
-                }
-            )
-            send_notification_mock.assert_called_with(
-                notification_type='removed',
-                options={
-                    'resource_name': 'schema.table',
-                    'resource_url': 'http://0.0.0.0:5000/table_detail/cluster/db/schema/table'
-                },
-                recipients=['test'],
-                sender=local_app.config['AUTH_USER_METHOD'](local_app).email
-            )
-
-    @responses.activate
     def test_get_last_indexed_success(self) -> None:
         """
         Test successful get_last_indexed request


### PR DESCRIPTION
### Summary of Changes

This PR improves the behavior of the automatic notifications that occur when an owner is added or removed. We now send a notification only on success of adding/removing the owner, and only if the user is not an alumni and is not a team.

The following changes were made to achieve this:
1. Notifications for owner notifications was removed from the Flask layer, all notifications are now triggered by some logic that occurs in the Redux layer. This provides us with more flexibility to explicitly call the `/notification` endpoint in specific cases.
2. Modified the method that generates the request to update the owner. If the update request succeeds, a request is added to the chain to get the user data for the given owner. A helper method evaluates if the user meets the criteria to get a notification, and then  a third request is added to the chain to send the notification. 

Other cleanup:
1.  The `notification` endpoint was updated to do more explicit error checking, and has helpful logic to get the sender if none is provided. This is helpful because it will prevent the application from needing to make a request to get the current user's email (sender), when that information is already available to the endpoint.
2. Cleaned up a type in the `OwnerEditor` component.


### Tests

Python tests modified according to changes. Tests for the new helper methods in `ducks/tableMetadata` were added. 

However `generateOwnerUpdateRequests` will be covered as part of a larger task to resolve some tech debt in the coverage of `ducks/tableMetadata/api/v0`

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
