### PR TITLE
Truncate the column type

### DIFF
--- a/amundsen_application/static/css/_popovers.scss
+++ b/amundsen_application/static/css/_popovers.scss
@@ -61,3 +61,8 @@
   width: 24px;
   margin: auto;
 }
+
+.column-type-popover {
+  max-width: 552px; // arbitrary 2x default
+  word-break: break-word;
+}

--- a/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
@@ -59,7 +59,7 @@ class DetailListItem extends React.Component<DetailListItemProps, DetailListItem
     let text = fullText;
 
     truncatedTypes.forEach((truncatedType) => {
-      if (type.startsWith(truncatedType)) {
+      if (type.startsWith(truncatedType) && type !== truncatedType) {
         shouldTrucate = true;
         text = `${truncatedType}<...>`;
         return;
@@ -80,7 +80,7 @@ class DetailListItem extends React.Component<DetailListItemProps, DetailListItem
           trigger={['click']}
           placement='right'
           overlay={popoverHover}
-          rootClose>
+          rootClose={true}>
             <a className='column-type'
                href="JavaScript:void(0)"
                onClick={ stopPropagation }

--- a/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
@@ -75,7 +75,7 @@ class DetailListItem extends React.Component<DetailListItemProps, DetailListItem
           <div className='title-section'>
             <div className='title-row'>
               <div className='name title-2'>{metadata.name}</div>
-              <div className='column-type'>{metadata.type ? metadata.type.toLowerCase() : 'null'}</div>
+              <div className='column-type truncated'>{metadata.type ? metadata.type.toLowerCase() : 'null'}</div>
             </div>
           </div>
           {

--- a/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import moment from 'moment-timezone';
 
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+
 import ColumnDescEditableText from 'components/TableDetail/ColumnDescEditableText';
 import { logClick } from 'ducks/utilMethods';
 import { TableColumn } from 'interfaces';
@@ -49,6 +51,48 @@ class DetailListItem extends React.Component<DetailListItemProps, DetailListItem
     return moment(unixEpochSeconds * 1000).format("MMM DD, YYYY");
   };
 
+  renderColumnType = (columnIndex: number, type: string) => {
+    const truncatedTypes: string[] = ['array', 'struct', 'map'];
+    let shouldTrucate = false;
+
+    const fullText = type.toLowerCase();
+    let text = fullText;
+
+    truncatedTypes.forEach((truncatedType) => {
+      if (type.startsWith(truncatedType)) {
+        shouldTrucate = true;
+        text = `${truncatedType}<...>`;
+        return;
+      };
+    })
+
+    if (shouldTrucate) {
+      const popoverHover = (
+        <Popover className='column-type-popover' id={`column-type-popover:${columnIndex}`}>
+          {fullText}
+        </Popover>
+      );
+      const stopPropagation = (event) => {
+        event.stopPropagation();
+      }
+      return (
+        <OverlayTrigger
+          trigger={['click']}
+          placement='right'
+          overlay={popoverHover}
+          rootClose>
+            <a className='column-type'
+               href="JavaScript:void(0)"
+               onClick={ stopPropagation }
+            >
+              {text}
+            </a>
+        </OverlayTrigger>
+      )
+    }
+    return (<div className='column-type'>{text}</div>);
+  };
+
   render() {
     const metadata = this.props.data;
     const isExpandable = metadata.stats && metadata.stats.length > 0;
@@ -75,7 +119,7 @@ class DetailListItem extends React.Component<DetailListItemProps, DetailListItem
           <div className='title-section'>
             <div className='title-row'>
               <div className='name title-2'>{metadata.name}</div>
-              <div className='column-type truncated'>{metadata.type ? metadata.type.toLowerCase() : 'null'}</div>
+              { this.renderColumnType(this.props.index, metadata.type) }
             </div>
           </div>
           {

--- a/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/DetailList/DetailListItem/styles.scss
@@ -47,6 +47,10 @@
           margin-top: 4px;
           max-width: 15%;
         }
+
+        a.column-type {
+          text-decoration: none;
+        }
       }
     }
 


### PR DESCRIPTION
### Summary of Changes

This PR truncated the column type for strings that start with `array`, `struct`, or `map` which have extended information. e.g. if the type is `array`, the text `array` will be rendered. If the type is `array...`, the text will be rendered as `array<...>` and on click will show the full text.

![Kapture 2019-09-16 at 10 16 33](https://user-images.githubusercontent.com/1790900/64978763-1e1f9f80-d86b-11e9-9b31-2931f1fe67f9.gif)

Implementation wise I considered creating a set of configurable "formatters" as we have these new use case to change how the column type is rendered (different folks might want different things) as well as numerical values (different folks will need different things due to internationalization). However given that a new design will be worked on for the concept of nested column types and this fix is a just a patch, I held off on introducing any new configurations until we understand the final requirements.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
