### PR TITLE
Custom routes + Further notification cleanup

### DIFF
--- a/amundsen_application/__init__.py
+++ b/amundsen_application/__init__.py
@@ -56,4 +56,8 @@ def create_app(config_module_class: str, template_folder: str = None) -> Flask:
     app.register_blueprint(search_blueprint)
     init_routes(app)
 
+    init_custom_routes = app.config.get('INIT_CUSTOM_ROUTES')
+    if init_custom_routes:
+        init_custom_routes(app)
+
     return app

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -1,5 +1,8 @@
 import os
-from typing import Dict, Optional, Set  # noqa: F401
+from typing import Callable, Dict, Optional, Set  # noqa: F401
+
+from flask import Flask  # noqa: F401
+
 from amundsen_application.tests.test_utils import get_test_user
 
 
@@ -21,6 +24,9 @@ class Config:
     # Mail Client Features
     MAIL_CLIENT = None
     NOTIFICATIONS_ENABLED = False
+
+    # Initialize custom routes
+    INIT_CUSTOM_ROUTES = None  # type: Callable[[Flask], None]
 
 
 class LocalConfig(Config):

--- a/amundsen_application/log/action_log.py
+++ b/amundsen_application/log/action_log.py
@@ -79,10 +79,7 @@ def _build_metrics(func_name: str,
     }  # type: Dict[str, Any]
 
     if flask_app.config['AUTH_USER_METHOD']:
-        try:
-            metrics['user'] = flask_app.config['AUTH_USER_METHOD'](flask_app).email
-        except Exception as e:
-            metrics['user'] = getpass.getuser()
+        metrics['user'] = flask_app.config['AUTH_USER_METHOD'](flask_app).email
     else:
         metrics['user'] = getpass.getuser()
 

--- a/amundsen_application/log/action_log.py
+++ b/amundsen_application/log/action_log.py
@@ -79,7 +79,10 @@ def _build_metrics(func_name: str,
     }  # type: Dict[str, Any]
 
     if flask_app.config['AUTH_USER_METHOD']:
-        metrics['user'] = flask_app.config['AUTH_USER_METHOD'](flask_app).email
+        try:
+            metrics['user'] = flask_app.config['AUTH_USER_METHOD'](flask_app).email
+        except Exception as e:
+            metrics['user'] = getpass.getuser()
     else:
         metrics['user'] = getpass.getuser()
 

--- a/amundsen_application/static/js/interfaces/Notifications.ts
+++ b/amundsen_application/static/js/interfaces/Notifications.ts
@@ -1,9 +1,8 @@
-// TODO: Remove notification types that can be triggered in flask layer if necessary
 export enum NotificationType {
-  OWNER_ADDED = 'added',
-  OWNER_REMOVED = 'removed',
-  METADATA_EDITED = 'edited',
-  METADATA_REQUESTED = 'requested',
+  OWNER_ADDED = 'owner_added',
+  OWNER_REMOVED = 'owner_removed',
+  METADATA_EDITED = 'metadata_edited',
+  METADATA_REQUESTED = 'metadata_requested',
 }
 
 export enum RequestMetadataType {

--- a/docs/flask_config.md
+++ b/docs/flask_config.md
@@ -4,6 +4,18 @@ After modifying any variable in [config.py](https://github.com/lyft/amundsenfron
 
 **NOTE: This document is a work in progress and does not include 100% of features. We welcome PRs to complete this document**
 
+## Custom Routes
+In order to add any custom Flask endpoints to Amundsen's frontend application, configure a function on the `INIT_CUSTOM_ROUTES` variable. This function takes the created Flask application and can leverage Flask's [add_url_rule](https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.add_url_rule) method to add custom routes.
+
+Example: Setting `INIT_CUSTOM_ROUTES` to the `init_custom_routes` method below will expose a `/custom_route` endpoint on the frontend application.
+```bash
+def init_custom_routes(app: Flask) -> None:
+  app.add_url_rule('/custom_route', 'custom_route', custom_route)
+
+def custom_route():
+  pass
+```
+
 ## Mail Client Features
 Amundsen has two features that leverage the custom mail client -- the feedback tool and notifications. For these features a custom implementation of [base_mail_client](https://github.com/lyft/amundsenfrontendlibrary/blob/master/amundsen_application/base/base_mail_client.py) must be mapped to the `MAIL_CLIENT` configuration variable.
 


### PR DESCRIPTION
### Summary of Changes

This PR adds a new feature to allow the configuration of custom and completes some cleanup in the notifications code.

1. There is a new config variable `INIT_CUSTOM_ROUTES`. It is a `Callable` that takes a Flask application and is called during `create_app`. This allows individuals to configure custom endpoints to support custom logic. In our case at Lyft, we are using it to hook on a new endpoint to our frontend application that will process some internal callback to generate some custom metrics.

2. In our python code I have added an enum class `NotificationType`, that matches the `NotificationType` interface in the frontend application, and replaced all usages of hardcoded notification type strings to leverage the enum class. This makes it easier to maintain the code snd prevent some human error when it comes to writing our notification logic.

3. For notification emails, instead of passing "notification" as the email type, we will pass the exact `notification_type` instead. This is more helpful because it will allow custom mail clients to execute specific logic based on the `notification_type`.

4. ~~In `_build_metrics()` in `action_log.py` we now catch any exceptions that occur when getting the `user` for metrics, and fallback to the default. The reason is that actions that are logged in any of the custom routes, if that endpoint was hit by another service as opposed to being the result of a user action -- the `AUTH_USER_METHOD` might encounter some error.~~

### Tests

Added a python test to cover calling `get_notification_subject()` with an unsupported notification type.

### Documentation

Added documentation for `INIT_CUSTOM_ROUTES` to `flask_config.md`.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
