### PR TITLE
Add source for notification email links

### DIFF
--- a/amundsen_application/api/utils/notification_utils.py
+++ b/amundsen_application/api/utils/notification_utils.py
@@ -86,8 +86,8 @@ def get_notification_html(*, notification_type: str, options: Dict, sender: str)
     validate_options(options=options)
 
     url_base = app.config['FRONTEND_BASE']
-    resource_url = '{url_base}{resource_path}'.format(resource_path=options.get('resource_path'),
-                                                      url_base=url_base)
+    resource_url = '{url_base}{resource_path}?source=notification'.format(resource_path=options.get('resource_path'),
+                                                                          url_base=url_base)
     joined_chars = resource_url[len(url_base) - 1:len(url_base) + 1]
     if joined_chars.count('/') != 1:
         raise Exception('Configured "FRONTEND_BASE" and "resource_path" do not form a valid url')

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -123,7 +123,7 @@ export class TableDetail extends React.Component<TableDetailProps & RouteCompone
     const searchIndex = params['index'];
     const source = params['source'];
     /* update the url stored in the browser history to remove params used for logging purposes */
-    if (searchIndex !== undefined) {
+    if (searchIndex !== undefined || source !== undefined) {
       window.history.replaceState({}, '', `${window.location.origin}${window.location.pathname}`);
     }
 

--- a/tests/unit/utils/notification/test_utils.py
+++ b/tests/unit/utils/notification/test_utils.py
@@ -110,7 +110,7 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>You have been added to the owners list of the '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a>'
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a>'
                         ' dataset by test@test.com.<br/><br/>What is expected of you?<br/>As an owner, you take an '
                         'important part in making sure that the datasets you own can be used as swiftly as possible '
                         'across the company.<br/>Make sure the metadata is correct and up to date.<br/><br/>If you '
@@ -132,9 +132,9 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>You have been removed from the owners list of the '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a> dataset by test@test.com.<br/><br/>If you'
-                        ' think you have been incorrectly removed as an owner, add yourself back to the owners list.'
-                        '<br/><br/>Thanks,<br/>Amundsen Team')
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a> dataset by'
+                        ' test@test.com.<br/><br/>If you think you have been incorrectly removed as an owner,'
+                        ' add yourself back to the owners list.<br/><br/>Thanks,<br/>Amundsen Team')
         self.assertEqual(html, expectedHTML)
 
     def test_get_notification_html_requested_success_all_fields(self) -> None:
@@ -156,7 +156,7 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>test@test.com is trying to use '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a>, '
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a>, '
                         'and requests improved table and column descriptions.<br/><br/>test@test.com has included the '
                         'following information with their request:<br/>Test Comment<br/><br/>Please visit the provided '
                         'link and improve descriptions on that resource.<br/><br/>Thanks,<br/>Amundsen Team')
@@ -180,7 +180,7 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>test@test.com is trying to use '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a>, and requests '
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a>, and requests '
                         'an improved table description.<br/><br/>Please visit the provided link and improve '
                         'descriptions on that resource.<br/><br/>Thanks,<br/>Amundsen Team')
         self.assertEqual(html, expectedHTML)
@@ -203,7 +203,7 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>test@test.com is trying to use '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a>, and requests '
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a>, and requests '
                         'improved column descriptions.<br/><br/>Please visit the provided link and improve '
                         'descriptions on that resource.<br/><br/>Thanks,<br/>Amundsen Team')
         self.assertEqual(html, expectedHTML)
@@ -225,7 +225,7 @@ class NotificationUtilsTest(unittest.TestCase):
                                          options=test_options,
                                          sender=test_sender)
         expectedHTML = ('Hello,<br/><br/>test@test.com is trying to use '
-                        '<a href="http://0.0.0.0:5000/testpath">testtable</a>, and requests '
+                        '<a href="http://0.0.0.0:5000/testpath?source=notification">testtable</a>, and requests '
                         'more information about that resource.<br/><br/>Please visit the provided link and improve '
                         'descriptions on that resource.<br/><br/>Thanks,<br/>Amundsen Team')
         self.assertEqual(html, expectedHTML)


### PR DESCRIPTION
### Summary of Changes

This PR adds the `source` logging parameter to notification email links and sets the source to "notification"

### Tests

Updated notification_utils test. Noted that we should eventually set up some improved helper methods to not have to manually update the expected html string any time there is a change.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
