### PR TITLE
Make table owner items clickable

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import ReactDOM from 'react-dom';
 import serialize from 'form-serialize';
 
+import AppConfig from 'config/config';
 import AvatarLabel, { AvatarLabelProps } from 'components/common/AvatarLabel';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 import { Modal } from 'react-bootstrap';
@@ -240,7 +241,13 @@ export class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorSt
 export const mapStateToProps = (state: GlobalState) => {
   const ownerObj = state.tableMetadata.tableOwners.owners;
   const items = Object.keys(ownerObj).reduce((obj, ownerId) => {
-    obj[ownerId] = { label: ownerObj[ownerId].display_name }
+    let link = ownerObj[ownerId].profile_url;
+    let target = '_blank';
+    if (AppConfig.indexUsers.enabled) {
+      link = `/user/${ownerObj[ownerId].user_id}?source=owners`;
+      target = '';
+    }
+    obj[ownerId] = { label: ownerObj[ownerId].display_name, link: link, target: target }
     return obj;
   }, {});
 

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -241,13 +241,13 @@ export class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorSt
 export const mapStateToProps = (state: GlobalState) => {
   const ownerObj = state.tableMetadata.tableOwners.owners;
   const items = Object.keys(ownerObj).reduce((obj, ownerId) => {
-    let link = ownerObj[ownerId].profile_url;
-    let target = '_blank';
+    let profileLink = ownerObj[ownerId].profile_url;
+    let docTarget = '_blank';
     if (AppConfig.indexUsers.enabled) {
-      link = `/user/${ownerObj[ownerId].user_id}?source=owners`;
-      target = '';
+      profileLink = `/user/${ownerObj[ownerId].user_id}?source=owned_by`;
+      docTarget = '';
     }
-    obj[ownerId] = { label: ownerObj[ownerId].display_name, link: link, target: target }
+    obj[ownerId] = { label: ownerObj[ownerId].display_name, link: profileLink, target: docTarget }
     return obj;
   }, {});
 

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -18,6 +18,7 @@ const DEFAULT_ERROR_TEXT = 'There was a problem with the request, please reload 
 
 import { GlobalState } from 'ducks/rootReducer';
 import { updateTableOwner } from 'ducks/tableMetadata/owners/reducer';
+import { logClick } from 'ducks/utilMethods';
 
 export interface DispatchFromProps {
   onUpdateList: (updateArray: UpdateOwnerPayload[], onSuccess?: () => any, onFailure?: () => any) => void;
@@ -199,11 +200,13 @@ export class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorSt
         <ul className='component-list'>
           {
             Object.keys(this.state.itemProps).map((key) => {
+              const ownerItem = this.state.tempItemProps[key]
               return (
                 <li key={`list-item:${key}`}>
-                  { React.createElement(AvatarLabel, this.state.itemProps[key]) }
-                </li>
-              );
+                  <a href={ownerItem.link} target={ownerItem.target} id="table-owners" onClick={logClick}>
+                    { <AvatarLabel label={ownerItem.label} src=''/> }
+                  </a>
+                </li> );
             })
           }
         </ul>

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -219,7 +219,7 @@ export class OwnerEditor extends React.Component<OwnerEditorProps, OwnerEditorSt
                   </a>
               } else {
                 listItem =
-                  <Link to={owner.link} target="_blank" id={`table-owners:${key}`} onClick={logClick}>
+                  <Link to={owner.link} id={`table-owners:${key}`} onClick={logClick}>
                     { avatarLabel }
                   </Link>
               }
@@ -268,16 +268,11 @@ export const mapStateToProps = (state: GlobalState) => {
   const ownerObj = state.tableMetadata.tableOwners.owners;
   const items = Object.keys(ownerObj).reduce((obj, ownerId) => {
     const { profile_url, user_id, display_name } = ownerObj[ownerId];
-    let profileLink;
-    let isExternalLink;
+    let profileLink = profile_url;
+    let isExternalLink = true;
     if (AppConfig.indexUsers.enabled) {
-      if (profile_url) {
-        isExternalLink = true;
-        profileLink = profile_url;
-      } else {
-        isExternalLink = false;
-        profileLink = `/user/${user_id}?source=owned_by`;
-      }
+      isExternalLink = false;
+      profileLink = `/user/${user_id}?source=owned_by`;
     }
     obj[ownerId] = { label: display_name, link: profileLink, isExternal: isExternalLink }
     return obj;

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -7,8 +7,6 @@ import './styles.scss';
 export interface AvatarLabelProps {
   label?: string;
   src?: string;
-  link?: string;
-  target?: string;
 }
 
 const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
@@ -24,9 +22,7 @@ const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
 
 AvatarLabel.defaultProps = {
   label: '',
-  src: '',
-  link: '',
-  target: ''
+  src: ''
 };
 
 export default AvatarLabel;

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import * as Avatar from 'react-avatar';
 
-import { Link } from 'react-router-dom';
-import { logClick } from 'ducks/utilMethods';
-
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
 
@@ -14,19 +11,11 @@ export interface AvatarLabelProps {
   target?: string;
 }
 
-const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src, link, target }) => {
+const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
   return (
     <div className='avatar-label-component'>
       <div id='component-avatar' className='component-avatar'>
-        <Link
-          to={ link }
-          target={ target }
-          className="avatar-overlap"
-          id="frequent-users"
-          onClick={logClick}
-        >
-          <Avatar name={label} src={src} size={25} round={true} />
-        </Link>
+        <Avatar name={label} src={src} size={24} round={true} />
       </div>
       <label id='component-label' className='component-label'>{label}</label>
     </div>

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -1,19 +1,32 @@
 import * as React from 'react';
 import * as Avatar from 'react-avatar';
 
+import { Link } from 'react-router-dom';
+import { logClick } from 'ducks/utilMethods';
+
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
 
 export interface AvatarLabelProps {
   label?: string;
   src?: string;
+  link?: string;
+  target?: string;
 }
 
-const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
+const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src, link, target }) => {
   return (
     <div className='avatar-label-component'>
       <div id='component-avatar' className='component-avatar'>
-        <Avatar name={label} src={src} size={24} round={true} />
+        <Link
+          to={ link }
+          target={ target }
+          className="avatar-overlap"
+          id="frequent-users"
+          onClick={logClick}
+        >
+          <Avatar name={label} src={src} size={25} round={true} />
+        </Link>
       </div>
       <label id='component-label' className='component-label'>{label}</label>
     </div>
@@ -22,7 +35,9 @@ const AvatarLabel: React.SFC<AvatarLabelProps> = ({ label, src }) => {
 
 AvatarLabel.defaultProps = {
   label: '',
-  src: ''
+  src: '',
+  link: '',
+  target: ''
 };
 
 export default AvatarLabel;


### PR DESCRIPTION
### Summary of Changes

Making table Owner items clickable like table Frequent Users.
An item click leads to a redirect to a user's homepage.

### Tests

No new tests.

### Documentation

No new documentation.

closes lyft/amundsen#146