### PR TITLE
Inline Search Improvements + Logging

### DIFF
--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
@@ -2,18 +2,19 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 export interface ResultItemProps {
-  href: string
+  id: string;
+  href: string;
   iconClass: string;
-  onItemSelect: () => void;
+  onItemSelect: (event: MouseEvent) => void;
   subtitle: string;
   title: string;
   type: string;
 }
 
-const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, onItemSelect, subtitle, title, type }) => {
+const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, id, onItemSelect, subtitle, title, type }) => {
   return (
     <li className="list-group-item">
-      <Link className="result-item-link" onClick={onItemSelect} to={ href }>
+      <Link id={id} className="result-item-link" onClick={onItemSelect} to={ href }>
         <img className={`result-icon ${iconClass}`} />
 
         <div className="result-info">

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/tests/index.spec.tsx
@@ -11,6 +11,7 @@ describe('ResultItem', () => {
 
   beforeAll(() => {
     props = {
+      id: 'foo',
       href: '/test',
       iconClass: 'test-icon',
       onItemSelect: jest.fn(),

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import { logClick } from 'ducks/utilMethods';
 import { ResourceType } from 'interfaces';
 
 import { SuggestedResult } from '../../InlineSearchResults'
@@ -26,18 +26,24 @@ class ResultItemList extends React.Component<ResultItemListProps, {}> {
     return `${RESULT_LIST_FOOTER_PREFIX}${totalResults} ${title}${RESULT_LIST_FOOTER_SUFFIX}`;
   }
 
-  onViewAllResults = () => {
+  onViewAllResults = (e) => {
+    logClick(e);
     this.props.onItemSelect(this.props.resourceType, true);
   };
 
   renderResultItems = (results: SuggestedResult[]) => {
-    const onResultItemSelect = () => this.props.onItemSelect(this.props.resourceType);
+    const onResultItemSelect = (e) => {
+      logClick(e);
+      this.props.onItemSelect(this.props.resourceType);
+    }
 
     return results.map((item, index) => {
       const { href, iconClass, subtitle, title, type } = item;
+      const id = `inline-resultitem-${this.props.resourceType}:${index}`;
       return (
         <ResultItem
-          key={`${this.props.resourceType}:${index}`}
+          key={id}
+          id={id}
           href={href}
           onItemSelect={onResultItemSelect}
           iconClass={`icon icon-dark ${iconClass}`}
@@ -48,9 +54,9 @@ class ResultItemList extends React.Component<ResultItemListProps, {}> {
       )
     });
   }
-  
+
   render = () => {
-    const { suggestedResults, title } = this.props;
+    const { resourceType, suggestedResults, title } = this.props;
     return (
       <>
         <div className="section-title title-3">{title}</div>
@@ -58,6 +64,7 @@ class ResultItemList extends React.Component<ResultItemListProps, {}> {
           { this.renderResultItems(suggestedResults) }
         </ul>
         <a
+          id={`inline-resultitem-viewall:${resourceType}`}
           className="section-footer title-3"
           onClick={this.onViewAllResults}
           target='_blank'

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
@@ -11,7 +11,7 @@ import { RESULT_LIST_FOOTER_PREFIX, RESULT_LIST_FOOTER_SUFFIX } from '../../cons
 import { logClick } from 'ducks/utilMethods';
 jest.mock('ducks/utilMethods', () => (
   {
-    logClick: jest.fn(() => {});
+    logClick: jest.fn(() => {}),
   }
 ));
 

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
@@ -8,6 +8,13 @@ import { ResourceType } from 'interfaces';
 
 import { RESULT_LIST_FOOTER_PREFIX, RESULT_LIST_FOOTER_SUFFIX } from '../../constants';
 
+import { logClick } from 'ducks/utilMethods';
+jest.mock('ducks/utilMethods', () => (
+  {
+    logClick: jest.fn(() => {});
+  }
+));
+
 describe('ResultItemList', () => {
   const setup = (propOverrides?: Partial<ResultItemListProps>) => {
     const props: ResultItemListProps = {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
@@ -50,7 +50,7 @@ describe('ResultItemList', () => {
     it('calls props.onItemSelect with the correct parameters', () => {
       const { props, wrapper } = setup();
       const onItemSelectSpy = jest.spyOn(props, 'onItemSelect');
-      wrapper.instance().onViewAllResults();
+      wrapper.instance().onViewAllResults({});
       expect(onItemSelectSpy).toHaveBeenCalledWith(props.resourceType, true);
     })
   });

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { logClick } from 'ducks/utilMethods';
 import { ResourceType } from 'interfaces';
 
 export interface SearchItemProps {
@@ -14,15 +15,17 @@ class SearchItem extends React.Component<SearchItemProps, {}> {
     super(props);
   }
 
-  onViewAllResults = () => {
+  onViewAllResults = (e) => {
+    logClick(e);
     this.props.onItemSelect(this.props.resourceType, true);
   }
 
   render = () => {
-    const { searchTerm, listItemText } = this.props;
+    const { searchTerm, listItemText, resourceType } = this.props;
     return (
       <li className="list-group-item">
         <a
+          id={`inline-searchitem-viewall:${resourceType}`}
           className="search-item-link"
           onClick={this.onViewAllResults}
           target='_blank'

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -9,7 +9,7 @@ import { ResourceType } from 'interfaces';
 import { logClick } from 'ducks/utilMethods';
 jest.mock('ducks/utilMethods', () => (
   {
-    logClick: jest.fn(() => {});
+    logClick: jest.fn(() => {}),
   }
 ));
 

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -23,7 +23,7 @@ describe('SearchItem', () => {
     it('calls props.onItemSelect with the correct parameters', () => {
       const { props, wrapper } = setup();
       const onItemSelectSpy = jest.spyOn(props, 'onItemSelect');
-      wrapper.instance().onViewAllResults();
+      wrapper.instance().onViewAllResults({});
       expect(onItemSelectSpy).toHaveBeenCalledWith(props.resourceType, true);
     })
   });

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -6,6 +6,13 @@ import SearchItem, { SearchItemProps } from '../';
 
 import { ResourceType } from 'interfaces';
 
+import { logClick } from 'ducks/utilMethods';
+jest.mock('ducks/utilMethods', () => (
+  {
+    logClick: jest.fn(() => {});
+  }
+));
+
 describe('SearchItem', () => {
   const setup = (propOverrides?: Partial<SearchItemProps>) => {
     const props: SearchItemProps = {

--- a/amundsen_application/static/js/components/common/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/index.tsx
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux';
 
 import { GlobalState } from 'ducks/rootReducer';
-import { submitSearch, getInlineResults, selectInlineResult } from 'ducks/search/reducer';
+import { submitSearch, getInlineResultsDebounce, selectInlineResult } from 'ducks/search/reducer';
 import { SubmitSearchRequest, InlineSearchRequest, InlineSearchSelect } from 'ducks/search/types';
 
 import { ResourceType } from 'interfaces';
@@ -210,7 +210,7 @@ export const mapStateToProps = (state: GlobalState) => {
 };
 
 export const mapDispatchToProps = (dispatch: any) => {
-  return bindActionCreators({ submitSearch, onInputChange: getInlineResults, onSelectInlineResult: selectInlineResult }, dispatch);
+  return bindActionCreators({ submitSearch, onInputChange: getInlineResultsDebounce, onSelectInlineResult: selectInlineResult }, dispatch);
 };
 
 export default connect<StateFromProps, DispatchFromProps, OwnProps>(mapStateToProps,  mapDispatchToProps)(SearchBar);

--- a/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/amundsen_application/static/js/ducks/rootSaga.ts
@@ -20,6 +20,7 @@ import { getPopularTablesWatcher } from './popularTables/sagas';
 // Search
 import {
   inlineSearchWatcher,
+  inlineSearchWatcherDebounce,
   loadPreviousSearchWatcher,
   searchAllWatcher,
   searchResourceWatcher,
@@ -64,6 +65,7 @@ export default function* rootSaga() {
     submitFeedbackWatcher(),
     // Search
     inlineSearchWatcher(),
+    inlineSearchWatcherDebounce(),
     loadPreviousSearchWatcher(),
     searchAllWatcher(),
     searchResourceWatcher(),

--- a/amundsen_application/static/js/ducks/search/reducer.ts
+++ b/amundsen_application/static/js/ducks/search/reducer.ts
@@ -78,6 +78,14 @@ export function searchResourceFailure(): SearchResourceResponse {
   return { type: SearchResource.FAILURE };
 };
 
+export function getInlineResultsDebounce(term: string): InlineSearchRequest {
+  return {
+    payload: {
+      term,
+    },
+    type: InlineSearch.REQUEST_DEBOUNCE,
+  };
+};
 export function getInlineResults(term: string): InlineSearchRequest {
   return {
     payload: {
@@ -263,6 +271,7 @@ export default function reducer(state: SearchReducerState = initialState, action
         },
       };
     case InlineSearch.REQUEST:
+    case InlineSearch.REQUEST_DEBOUNCE:
       return {
         ...state,
         inlineResults: {

--- a/amundsen_application/static/js/ducks/search/sagas.ts
+++ b/amundsen_application/static/js/ducks/search/sagas.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from 'redux-saga';
-import { all, call, debounce, put, select, takeEvery } from 'redux-saga/effects';
+import { all, call, debounce, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import * as qs from 'simple-query-string';
 
 import { ResourceType } from 'interfaces/Resources';
@@ -33,6 +33,7 @@ import {
   searchResourceFailure,
   searchResourceSuccess,
   getInlineResults,
+  getInlineResultsDebounce,
   getInlineResultsSuccess,
   getInlineResultsFailure,
   updateFromInlineResult,
@@ -58,7 +59,13 @@ export function* inlineSearchWorker(action: InlineSearchRequest): SagaIterator {
   }
 };
 export function* inlineSearchWatcher(): SagaIterator {
-  yield debounce(350, InlineSearch.REQUEST, inlineSearchWorker)
+  yield takeLatest(InlineSearch.REQUEST, inlineSearchWorker);
+}
+export function* debounceWorker(action): SagaIterator {
+  yield put(getInlineResults(action.payload.term));
+}
+export function* inlineSearchWatcherDebounce(): SagaIterator {
+  yield debounce(350, InlineSearch.REQUEST_DEBOUNCE, debounceWorker);
 }
 
 export function* selectInlineResultWorker(action): SagaIterator {

--- a/amundsen_application/static/js/ducks/search/types.ts
+++ b/amundsen_application/static/js/ducks/search/types.ts
@@ -85,6 +85,7 @@ export interface SearchResourceResponse {
 
 export enum InlineSearch {
   REQUEST = 'amundsen/search/INLINE_SEARCH_REQUEST',
+  REQUEST_DEBOUNCE = 'amundsen/search/INLINE_SEARCH_REQUEST_DEBOUNCE',
   SELECT = 'amundsen/search/INLINE_SEARCH_SELECT',
   SUCCESS = 'amundsen/search/INLINE_SEARCH_SUCCESS',
   FAILURE = 'amundsen/search/INLINE_SEARCH_FAILURE',
@@ -94,7 +95,7 @@ export interface InlineSearchRequest {
   payload: {
     term: string;
   };
-  type: InlineSearch.REQUEST;
+  type: InlineSearch.REQUEST | InlineSearch.REQUEST_DEBOUNCE;
 };
 export interface InlineSearchResponse {
   type: InlineSearch.SUCCESS | InlineSearch.FAILURE;


### PR DESCRIPTION
### Summary of Changes

#### ducks
The current inline search saga behavior uses `debounce`, which prevents a request from being fired for each keystroke. However it does not fully prevent against a slower-typing user seeing intermediate results as they type. **_Example:_** Depending on how fast someone types "ttannis", they could briefly see no results for "ttan" as they are still typing. 

With the existing changes, this "glitchy" behavior is much less likely to happen, as the UI will only show the results of the latest debounced request. Alternatively we *could* have increased the debounce time, but this would also have led to a slower experience for users who type quickly. I find the current changes to be a good middle-ground and improvement upon the existing experience.

#### logging
Added `logClick` on the clickable components in `InlineSearchResults`. A custom id has been added to these components to be captured in the log.

### Tests

TODO after approval of logic

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
