### PR TITLE
Adding a separate oidc version of the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE := amundsendev/amundsen-frontend
+OIDC_IMAGE := ${IMAGE}-oidc
 VERSION:= $(shell grep -m 1 '__version__' setup.py | cut -d '=' -f 2 | tr -d "'" | tr -d '[:space:]')
 
 .PHONY: clean
@@ -32,5 +33,15 @@ push-image:
 	docker push ${IMAGE}:${VERSION}
 	docker push ${IMAGE}:latest
 
+.PHONY: oidc-image
+oidc-image:
+	docker build -f public.Dockerfile --target=oidc-release -t ${OIDC_IMAGE}:${VERSION} .
+	docker tag ${OIDC_IMAGE}:${VERSION} ${OIDC_IMAGE}:latest
+
+.PHONY: push-odic-image
+push-oidc-image:
+	docker push ${OIDC_IMAGE}:${VERSION}
+	docker push ${OIDC_IMAGE}:latest
+
 .PHONY: build-push-image
-build-push-image: image push-image
+build-push-image: image oidc-image push-image push-oidc-image

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -1,7 +1,9 @@
 import os
 from typing import Callable, Dict, Optional, Set  # noqa: F401
+from amundsen_application.models.user import User
 
 from flask import Flask  # noqa: F401
+from flask import current_app as app
 
 from amundsen_application.tests.test_utils import get_test_user
 
@@ -69,9 +71,9 @@ class LocalConfig(Config):
     # Please note that if specified, this will ignore following config properties:
     # 1. METADATASERVICE_REQUEST_HEADERS
     # 2. SEARCHSERVICE_REQUEST_HEADERS
-    REQUEST_HEADERS_METHOD = None
+    REQUEST_HEADERS_METHOD: Optional[Callable[[app], Optional[Dict]]] = None
 
-    AUTH_USER_METHOD = None  # type: Optional[function]
+    AUTH_USER_METHOD: Optional[Callable[[app], User]] = None
     GET_PROFILE_URL = None
 
 

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -3,7 +3,6 @@ from typing import Callable, Dict, Optional, Set  # noqa: F401
 from amundsen_application.models.user import User
 
 from flask import Flask  # noqa: F401
-from flask import current_app as app
 
 from amundsen_application.tests.test_utils import get_test_user
 
@@ -71,9 +70,9 @@ class LocalConfig(Config):
     # Please note that if specified, this will ignore following config properties:
     # 1. METADATASERVICE_REQUEST_HEADERS
     # 2. SEARCHSERVICE_REQUEST_HEADERS
-    REQUEST_HEADERS_METHOD: Optional[Callable[[app], Optional[Dict]]] = None
+    REQUEST_HEADERS_METHOD: Optional[Callable[[Flask], Optional[Dict]]] = None
 
-    AUTH_USER_METHOD: Optional[Callable[[app], User]] = None
+    AUTH_USER_METHOD: Optional[Callable[[Flask], User]] = None
     GET_PROFILE_URL = None
 
 

--- a/amundsen_application/oidc_config.py
+++ b/amundsen_application/oidc_config.py
@@ -1,9 +1,10 @@
-from typing import Dict, Any
-from flask import Flask
+from typing import Dict, Any, Optional
+from flask import current_app as app
 from amundsen_application.config import LocalConfig
+from amundsen_application.models.user import load_user, User
 
 
-def get_access_headers(app: Flask) -> Dict:
+def get_access_headers(app: app) -> Optional[Dict]:
     """
     Function to retrieve and format the Authorization Headers
     that can be passed to various microservices who are expecting that.
@@ -18,7 +19,7 @@ def get_access_headers(app: Flask) -> Dict:
         return None
 
 
-def get_auth_user(app: Flask) -> Any:
+def get_auth_user(app: app) -> User:
     """
     Retrieves the user information from oidc token, and then makes
     a dictionary 'UserInfo' from the token information dictionary.
@@ -28,10 +29,7 @@ def get_auth_user(app: Flask) -> Any:
     :return: A class UserInfo (Note, there isn't a UserInfo class, so we use Any)
     """
     from flask import g
-    app.logger.info(g.oidc_id_token)
-    user_info = type('UserInfo', (object,), g.oidc_id_token)
-    # noinspection PyUnresolvedReferences
-    user_info.user_id = user_info.preferred_username
+    user_info = load_user(g.oidc_id_token)
     return user_info
 
 

--- a/amundsen_application/oidc_config.py
+++ b/amundsen_application/oidc_config.py
@@ -1,0 +1,37 @@
+from amundsen_application.config import LocalConfig
+
+
+def get_access_headers(app):
+    """
+    Function to retrieve and format the Authorization Headers
+    that can be passed to various microservices who are expecting that.
+    :param oidc: OIDC object having authorization information
+    :return: A formatted dictionary containing access token
+    as Authorization header.
+    """
+    try:
+        access_token = app.oidc.get_access_token()
+        return {'Authorization': 'Bearer {}'.format(access_token)}
+    except Exception:
+        return None
+
+
+def get_auth_user(app):
+    """
+    Retrieves the user information from oidc token, and then makes
+    a dictionary 'UserInfo' from the token information dictionary.
+    We need to convert it to a class in order to use the information
+    in the rest of the Amundsen application.
+    :param app: The instance of the current app.
+    :return: A class UserInfo
+    """
+    from flask import g
+    user_info = type('UserInfo', (object,), g.oidc_id_token)
+    # noinspection PyUnresolvedReferences
+    user_info.user_id = user_info.preferred_username
+    return user_info
+
+
+class OidcConfig(LocalConfig):
+    AUTH_USER_METHOD = get_auth_user
+    REQUEST_HEADERS_METHOD = get_access_headers

--- a/amundsen_application/oidc_config.py
+++ b/amundsen_application/oidc_config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Optional
 from flask import Flask
 from amundsen_application.config import LocalConfig
 from amundsen_application.models.user import load_user, User

--- a/amundsen_application/oidc_config.py
+++ b/amundsen_application/oidc_config.py
@@ -1,10 +1,10 @@
 from typing import Dict, Any, Optional
-from flask import current_app as app
+from flask import Flask
 from amundsen_application.config import LocalConfig
 from amundsen_application.models.user import load_user, User
 
 
-def get_access_headers(app: app) -> Optional[Dict]:
+def get_access_headers(app: Flask) -> Optional[Dict]:
     """
     Function to retrieve and format the Authorization Headers
     that can be passed to various microservices who are expecting that.
@@ -19,7 +19,7 @@ def get_access_headers(app: app) -> Optional[Dict]:
         return None
 
 
-def get_auth_user(app: app) -> User:
+def get_auth_user(app: Flask) -> User:
     """
     Retrieves the user information from oidc token, and then makes
     a dictionary 'UserInfo' from the token information dictionary.

--- a/amundsen_application/oidc_config.py
+++ b/amundsen_application/oidc_config.py
@@ -1,7 +1,9 @@
+from typing import Dict, Any
+from flask import Flask
 from amundsen_application.config import LocalConfig
 
 
-def get_access_headers(app):
+def get_access_headers(app: Flask) -> Dict:
     """
     Function to retrieve and format the Authorization Headers
     that can be passed to various microservices who are expecting that.
@@ -16,16 +18,17 @@ def get_access_headers(app):
         return None
 
 
-def get_auth_user(app):
+def get_auth_user(app: Flask) -> Any:
     """
     Retrieves the user information from oidc token, and then makes
     a dictionary 'UserInfo' from the token information dictionary.
     We need to convert it to a class in order to use the information
     in the rest of the Amundsen application.
     :param app: The instance of the current app.
-    :return: A class UserInfo
+    :return: A class UserInfo (Note, there isn't a UserInfo class, so we use Any)
     """
     from flask import g
+    app.logger.info(g.oidc_id_token)
     user_info = type('UserInfo', (object,), g.oidc_id_token)
     # noinspection PyUnresolvedReferences
     user_info.user_id = user_info.preferred_username

--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 COPY amundsen_application/static /app/amundsen_application/static
 RUN npm run build
 
-FROM python:3.7-slim
+FROM python:3.7-slim as base
 WORKDIR /app
 RUN pip3 install gunicorn
 
@@ -20,3 +20,19 @@ COPY . /app
 RUN python3 setup.py install
 
 CMD [ "python3",  "amundsen_application/wsgi.py" ]
+
+FROM base as oidc-release
+
+RUN pip3 install -r requirements3-oidc.txt
+ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
+ENV APP_WRAPPER flaskoidc
+ENV APP_WRAPPER_CLASS FlaskOIDC
+ENV FLASK_OIDC_WHITELISTED_ENDPOINTS status,healthcheck,health
+ENV FLASK_OIDC_SQLALCHEMY_DATABASE_URI sqlite:///sessions.db
+
+# You will need to set these environment variables in order to use the oidc image
+# FLASK_OIDC_CLIENT_SECRETS - a path to a client_secrets.json file
+# FLASK_OIDC_SECRET_KEY - A secret key from your oidc provider
+# You will also need to mount a volume for the clients_secrets.json file.
+
+FROM base as release

--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -23,7 +23,7 @@ CMD [ "python3",  "amundsen_application/wsgi.py" ]
 
 FROM base as oidc-release
 
-RUN pip3 install -r requirements3-oidc.txt
+RUN pip3 install .[oidc]
 ENV FRONTEND_SVC_CONFIG_MODULE_CLASS amundsen_application.oidc_config.OidcConfig
 ENV APP_WRAPPER flaskoidc
 ENV APP_WRAPPER_CLASS FlaskOIDC

--- a/requirements3-oidc.txt
+++ b/requirements3-oidc.txt
@@ -1,4 +1,0 @@
-# A wrapper of Flask with pre-configured OIDC support.
-# License: Apache License 2.0
-# Upstream url: https://github.com/verdan/flaskoidc
-flaskoidc==0.0.2

--- a/requirements3-oidc.txt
+++ b/requirements3-oidc.txt
@@ -1,0 +1,4 @@
+# A wrapper of Flask with pre-configured OIDC support.
+# License: Apache License 2.0
+# Upstream url: https://github.com/verdan/flaskoidc
+flaskoidc==0.0.2

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
     include_package_data=True,
     dependency_links=[],
     install_requires=requirements,
+    extras_require={
+        'oidc': ['flaskoidc==0.0.2']
+    },
     python_requires=">=3.6",
     entry_points="""
         [action_log.post_exec.plugin]


### PR DESCRIPTION
I was making my own image with oidc based on the instructions in the repo and I was thinking it would be simpler if the main build processes just also made that image. 

I ran both images this builds and everything seems to work. 

If everyone is happy with this approach, I can do the same for the metadata repo and update the helm chart too. 