### PR TITLE
Improve InlineSearch UI

### DIFF
--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -2,9 +2,17 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { SearchItem, SearchItemProps } from '../';
+import LoadingSpinner from 'components/common/LoadingSpinner';
+import { SearchItem, SearchItemProps, mapStateToProps } from '../';
+
+import {
+  SEARCH_ITEM_NO_RESULTS
+} from 'components/common/SearchBar/InlineSearchResults/constants';
 
 import { ResourceType } from 'interfaces';
+
+import globalState from 'fixtures/globalState';
+import { allResourcesExample, isLoadingExample, noResultsExample } from 'fixtures/search/inlineResults';
 
 import { logClick } from 'ducks/utilMethods';
 jest.mock('ducks/utilMethods', () => (
@@ -37,13 +45,37 @@ describe('SearchItem', () => {
     })
   });
 
+  describe('renderIndicator', () => {
+    it('renders LoadingSpinner if props.isLoading', () => {
+      const { props, wrapper } = setup({ isLoading: true });
+      const content = shallow(<div>{wrapper.instance().renderIndicator()}</div>);
+      expect(content.find(LoadingSpinner).exists()).toBe(true);
+    });
+
+    it('renders correct text if !props.hasResults', () => {
+      const { props, wrapper } = setup({ hasResults: false });
+      const content = shallow(wrapper.instance().renderIndicator());
+      expect(content.text()).toBe(SEARCH_ITEM_NO_RESULTS);
+    });
+
+    it('renders nothing if !props.Loading and props.hasResults', () => {
+      const { props, wrapper } = setup({ isLoading: false, hasResults: true});
+      expect(wrapper.instance().renderIndicator()).toBe(null);
+    });
+  });
+
   describe('render', () => {
     let props;
     let wrapper;
+    let renderIndicatorSpy;
+    let mockContent;
     beforeAll(() => {
       const setUpResult = setup();
       props = setUpResult.props;
       wrapper = setUpResult.wrapper;
+      mockContent = (<div>Hello</div>);
+      renderIndicatorSpy = jest.spyOn(wrapper.instance(), 'renderIndicator').mockImplementation(() => mockContent);
+      wrapper.instance().forceUpdate();
     });
 
     describe('renders list item link', () => {
@@ -66,8 +98,86 @@ describe('SearchItem', () => {
         });
 
         it('renders correct text', () => {
-          expect(listItemLink.text()).toEqual(`${props.searchTerm}\u00a0${props.listItemText}`);
+          expect(listItemLink.find('.search-item-info').text()).toEqual(`${props.searchTerm}\u00a0${props.listItemText}`);
         });
+
+        it('renders results of renderIndicator', () => {
+          expect(listItemLink.children().at(2).html()).toEqual("<div>Hello</div>");
+        });
+      });
+    });
+
+    it('calls renderIndicator', () => {
+      renderIndicatorSpy.mockClear();
+      wrapper.instance().render();
+      expect(renderIndicatorSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    let result;
+    let ownProps;
+    let mockLoadingState;
+    let mockAllResultsState;
+    let mockNoResultsState;
+
+    beforeAll(() => {
+      mockLoadingState = {
+        ...globalState,
+        search: {
+          ...globalState.search,
+          inlineResults: isLoadingExample,
+        }
+      };
+      mockAllResultsState = {
+        ...globalState,
+        search: {
+          ...globalState.search,
+          inlineResults: allResourcesExample,
+        }
+      };
+      mockNoResultsState = {
+        ...globalState,
+        search: {
+          ...globalState.search,
+          inlineResults: noResultsExample,
+        }
+      };
+    })
+
+    it('sets isLoading on the props', () => {
+      ownProps = setup().props;
+      result = mapStateToProps(mockLoadingState, ownProps);
+      expect(result.isLoading).toEqual(true);
+    });
+
+    describe('ownProps.resourceType is ResourceType.table', () => {
+      beforeAll(() => {
+        ownProps = setup({resourceType: ResourceType.table}).props;
+      });
+      it('sets hasResults to true if there are table results', () => {
+        result = mapStateToProps(mockAllResultsState, ownProps);
+        expect(result.hasResults).toEqual(true);
+      });
+
+      it('sets hasResults to false if there are no table results', () => {
+        result = mapStateToProps(mockNoResultsState, ownProps);
+        expect(result.hasResults).toEqual(false);
+      });
+    });
+
+    describe('ownProps.resourceType is ResourceType.user', () => {
+      beforeAll(() => {
+        ownProps = setup({resourceType: ResourceType.user}).props;
+      })
+      it('sets hasResults to true if there are user results', () => {
+        result = mapStateToProps(mockAllResultsState, ownProps);
+        expect(result.hasResults).toEqual(true);
+      });
+
+      it('sets hasResults to false if there are no user results', () => {
+        result = mapStateToProps(mockNoResultsState, ownProps);
+        expect(result.hasResults).toEqual(false);
       });
     });
   });

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import SearchItem, { SearchItemProps } from '../';
+import { SearchItem, SearchItemProps } from '../';
 
 import { ResourceType } from 'interfaces';
 
@@ -20,6 +20,8 @@ describe('SearchItem', () => {
       onItemSelect: jest.fn(),
       searchTerm: 'test search',
       resourceType: ResourceType.table,
+      isLoading: false,
+      hasResults: true,
       ...propOverrides
     };
     const wrapper = shallow<SearchItem>(<SearchItem {...props} />);

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/SearchItem/tests/index.spec.tsx
@@ -11,6 +11,7 @@ import {
 
 import { ResourceType } from 'interfaces';
 
+import { GlobalState } from 'ducks/rootReducer'
 import globalState from 'fixtures/globalState';
 import { allResourcesExample, isLoadingExample, noResultsExample } from 'fixtures/search/inlineResults';
 
@@ -117,33 +118,28 @@ describe('SearchItem', () => {
   describe('mapStateToProps', () => {
     let result;
     let ownProps;
-    let mockLoadingState;
-    let mockAllResultsState;
-    let mockNoResultsState;
-
-    beforeAll(() => {
-      mockLoadingState = {
-        ...globalState,
-        search: {
-          ...globalState.search,
-          inlineResults: isLoadingExample,
-        }
-      };
-      mockAllResultsState = {
-        ...globalState,
-        search: {
-          ...globalState.search,
-          inlineResults: allResourcesExample,
-        }
-      };
-      mockNoResultsState = {
-        ...globalState,
-        search: {
-          ...globalState.search,
-          inlineResults: noResultsExample,
-        }
-      };
-    })
+    const mockLoadingState: GlobalState = {
+      ...globalState,
+      search: {
+        ...globalState.search,
+        inlineResults: isLoadingExample,
+      }
+    };
+    const mockAllResultsState: GlobalState = {
+      ...globalState,
+      search: {
+        ...globalState.search,
+        // @ts-ignore: https://github.com/microsoft/TypeScript/issues/10570
+        inlineResults: allResourcesExample,
+      }
+    };
+    const mockNoResultsState: GlobalState = {
+      ...globalState,
+      search: {
+        ...globalState.search,
+        inlineResults: noResultsExample,
+      }
+    };
 
     it('sets isLoading on the props', () => {
       ownProps = setup().props;

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/SearchItemList/tests/index.spec.tsx
@@ -12,6 +12,14 @@ import * as CONSTANTS from '../../constants';
 jest.mock('config/config-utils', () => ({ indexUsersEnabled: jest.fn() }));
 import { indexUsersEnabled } from 'config/config-utils';
 
+jest.mock("react-redux", () => {
+  return {
+    connect: (mapStateToProps, mapDispatchToProps) => (
+      SearchItem
+    ) => SearchItem
+  };
+});
+
 describe('SearchItemList', () => {
   const setup = (propOverrides?: Partial<SearchItemListProps>) => {
     const props: SearchItemListProps = {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/constants.ts
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/constants.ts
@@ -11,3 +11,5 @@ export const USER_ICON_CLASS = "icon-users";
 
 export const RESULT_LIST_FOOTER_PREFIX = "See all";
 export const RESULT_LIST_FOOTER_SUFFIX = "results";
+
+export const SEARCH_ITEM_NO_RESULTS = "No results found";

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux'
 
-import LoadingSpinner from 'components/common/LoadingSpinner';
 import SearchItemList from './SearchItemList';
 import ResultItemList from './ResultItemList';
 
@@ -153,44 +152,42 @@ export class InlineSearchResults extends React.Component<InlineSearchResultsProp
   };
 
   renderResultsByResource = (resourceType: ResourceType) => {
-    return (
-      <div className="inline-results-section">
-        <ResultItemList
-          onItemSelect={this.props.onItemSelect}
-          resourceType={resourceType}
-          searchTerm={this.props.searchTerm}
-          suggestedResults={this.getSuggestedResultsForResource(resourceType)}
-          totalResults={this.getTotalResultsForResource(resourceType)}
-          title={this.getTitleForResource(resourceType)}
-        />
-      </div>
-    )
+    const suggestedResults = this.getSuggestedResultsForResource(resourceType);
+    if (suggestedResults.length > 0) {
+      return (
+        <div className="inline-results-section">
+          <ResultItemList
+            onItemSelect={this.props.onItemSelect}
+            resourceType={resourceType}
+            searchTerm={this.props.searchTerm}
+            suggestedResults={this.getSuggestedResultsForResource(resourceType)}
+            totalResults={this.getTotalResultsForResource(resourceType)}
+            title={this.getTitleForResource(resourceType)}
+          />
+        </div>
+      )
+    }
   };
 
   renderResults = () => {
-    if (this.props.isLoading) {
+    if (!this.props.isLoading) {
       return (
-        <div className="inline-results-section">
-          <LoadingSpinner/>
-        </div>
+        <>
+          { this.renderResultsByResource(ResourceType.table) }
+          {
+            indexUsersEnabled() &&
+            this.renderResultsByResource(ResourceType.user)
+          }
+        </>
       );
     }
-    return (
-      <>
-        { this.renderResultsByResource(ResourceType.table) }
-        {
-          indexUsersEnabled() &&
-          this.renderResultsByResource(ResourceType.user)
-        }
-      </>
-    );
   }
 
   render() {
     const { className = '', onItemSelect, searchTerm } = this.props;
     return (
       <div id="inline-results" className={`inline-results ${className}`}>
-        <div className="inline-results-section">
+        <div className="inline-results-section search-item-section">
           <SearchItemList
             onItemSelect={onItemSelect}
             searchTerm={searchTerm}

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
@@ -153,34 +153,36 @@ export class InlineSearchResults extends React.Component<InlineSearchResultsProp
 
   renderResultsByResource = (resourceType: ResourceType) => {
     const suggestedResults = this.getSuggestedResultsForResource(resourceType);
-    if (suggestedResults.length > 0) {
-      return (
-        <div className="inline-results-section">
-          <ResultItemList
-            onItemSelect={this.props.onItemSelect}
-            resourceType={resourceType}
-            searchTerm={this.props.searchTerm}
-            suggestedResults={this.getSuggestedResultsForResource(resourceType)}
-            totalResults={this.getTotalResultsForResource(resourceType)}
-            title={this.getTitleForResource(resourceType)}
-          />
-        </div>
-      )
+    if (suggestedResults.length === 0) {
+      return null;
     }
+    return (
+      <div className="inline-results-section">
+        <ResultItemList
+          onItemSelect={this.props.onItemSelect}
+          resourceType={resourceType}
+          searchTerm={this.props.searchTerm}
+          suggestedResults={suggestedResults}
+          totalResults={this.getTotalResultsForResource(resourceType)}
+          title={this.getTitleForResource(resourceType)}
+        />
+      </div>
+    )
   };
 
   renderResults = () => {
-    if (!this.props.isLoading) {
-      return (
-        <>
-          { this.renderResultsByResource(ResourceType.table) }
-          {
-            indexUsersEnabled() &&
-            this.renderResultsByResource(ResourceType.user)
-          }
-        </>
-      );
+    if (this.props.isLoading) {
+      return null;
     }
+    return (
+      <>
+        { this.renderResultsByResource(ResourceType.table) }
+        {
+          indexUsersEnabled() &&
+          this.renderResultsByResource(ResourceType.user)
+        }
+      </>
+    );
   }
 
   render() {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
@@ -25,17 +25,19 @@
     }
   }
 
-  .inline-results-section {
-    padding-top: 8px;
-    padding-bottom: 8px;
+  .search-item-section {
+    padding-top: $spacer-1;
+    padding-bottom: $spacer-1;
+  }
 
+  .inline-results-section {
     &:not(:last-of-type) {
       border-bottom: 1px solid $stroke;
     }
 
     .section-title,
     .section-footer {
-      margin-left: 24px;
+      margin: $spacer-1 0 $spacer-1 $spacer-3;
     }
 
     a.section-footer {
@@ -90,6 +92,20 @@
               font-weight: $font-weight-body-regular;
             }
           }
+
+          .loading-spinner {
+            width: 24px;
+            height: 24px;
+          }
+
+          .loading-spinner,
+          .search-item-indicator {
+            margin: auto 0 auto $spacer-1;
+          }
+
+          .search-item-indicator {
+            font-style: italic;
+          }
         }
 
         /* RESULT ITEM */
@@ -108,10 +124,5 @@
         }
       }
     }
-  }
-
-  .loading-spinner {
-    margin-top: 5%;
-    margin-bottom: 5%;
   }
 }

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
@@ -17,6 +17,7 @@
 
     .result-item-link {
       padding-left: 20px !important;
+      padding-right: 20px !important;
     }
 
     .section-footer.title-3,
@@ -37,7 +38,7 @@
 
     .section-title,
     .section-footer {
-      margin: $spacer-1 0 $spacer-1 $spacer-3;
+      margin: $spacer-1 $spacer-3;
     }
 
     a.section-footer {
@@ -111,7 +112,7 @@
         /* RESULT ITEM */
         .result-item-link {
           height: 56px;
-          padding: 8px 8px 8px 32px;
+          padding: 8px 32px;
           .result-info {
             display: flex;
             flex: 1;

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
@@ -309,44 +309,70 @@ describe('InlineSearchResults', () => {
     let getTotalResultsForResourceSpy;
     let mockTitle;
     let getTitleForResourceSpy;
-    beforeAll(() => {
-      const setupResult = setup();
-      props = setupResult.props;
-      wrapper = setupResult.wrapper;
-      mockResults = [
-        { href: '/test', iconClass: 'test-class', subtitle: 'subtitle', title: 'title', type: 'User' },
-        { href: '/test2', iconClass: 'test-class2', subtitle: 'subtitle2', title: 'title2', type: 'User' },
-      ]
-      getSuggestedResultsForResourceSpy = jest.spyOn(wrapper.instance(), 'getSuggestedResultsForResource').mockImplementation(() => mockResults);
-      mockTotal = 65;
-      getTotalResultsForResourceSpy = jest.spyOn(wrapper.instance(), 'getTotalResultsForResource').mockImplementation(() => mockTotal);
-      mockTitle = 'Datasets';
-      getTitleForResourceSpy = jest.spyOn(wrapper.instance(), 'getTitleForResource').mockImplementation(() => mockTitle);
-      wrapper.instance().forceUpdate();
+
+    describe('if results do not exist', () => {
+      beforeAll(() => {
+        const setupResult = setup();
+        props = setupResult.props;
+        wrapper = setupResult.wrapper;
+        mockResults = []
+        getSuggestedResultsForResourceSpy = jest.spyOn(wrapper.instance(), 'getSuggestedResultsForResource').mockImplementation(() => mockResults);
+        wrapper.instance().forceUpdate();
+      });
+
+      it('calls helper methods with given resourceType', () => {
+        getSuggestedResultsForResourceSpy.mockClear();
+        const givenResourceType = ResourceType.dashboard;
+        wrapper.instance().renderResultsByResource(givenResourceType);
+        expect(getSuggestedResultsForResourceSpy).toHaveBeenCalledWith(givenResourceType);
+      });
+
+      it('renders nothing', () => {
+        const givenResourceType = ResourceType.dashboard;
+        expect(wrapper.instance().renderResultsByResource(givenResourceType)).toBe(null);
+      });
     });
 
-    it('calls helper methods with given resourceType', () => {
-      getSuggestedResultsForResourceSpy.mockClear();
-      getTotalResultsForResourceSpy.mockClear();
-      getTitleForResourceSpy.mockClear();
-      const givenResourceType = ResourceType.dashboard;
-      wrapper.instance().renderResultsByResource(givenResourceType);
-      expect(getSuggestedResultsForResourceSpy).toHaveBeenCalledWith(givenResourceType);
-      expect(getTotalResultsForResourceSpy).toHaveBeenCalledWith(givenResourceType);
-      expect(getTitleForResourceSpy).toHaveBeenCalledWith(givenResourceType);
-    });
+    describe('if results exist', () => {
+      beforeAll(() => {
+        const setupResult = setup();
+        props = setupResult.props;
+        wrapper = setupResult.wrapper;
+        mockResults = [
+          { href: '/test', iconClass: 'test-class', subtitle: 'subtitle', title: 'title', type: 'User' },
+          { href: '/test2', iconClass: 'test-class2', subtitle: 'subtitle2', title: 'title2', type: 'User' },
+        ]
+        getSuggestedResultsForResourceSpy = jest.spyOn(wrapper.instance(), 'getSuggestedResultsForResource').mockImplementation(() => mockResults);
+        mockTotal = 65;
+        getTotalResultsForResourceSpy = jest.spyOn(wrapper.instance(), 'getTotalResultsForResource').mockImplementation(() => mockTotal);
+        mockTitle = 'Datasets';
+        getTitleForResourceSpy = jest.spyOn(wrapper.instance(), 'getTitleForResource').mockImplementation(() => mockTitle);
+        wrapper.instance().forceUpdate();
+      });
 
-    it('renders ResultItemList with expected props', () => {
-      const givenResourceType = ResourceType.dashboard;
-      const content = shallow(wrapper.instance().renderResultsByResource(givenResourceType));
-      const item = content.find('.inline-results-section').find(ResultItemList);
-      const itemProps = item.props();
-      expect(itemProps.onItemSelect).toEqual(props.onItemSelect);
-      expect(itemProps.resourceType).toEqual(givenResourceType);
-      expect(itemProps.suggestedResults).toEqual(mockResults);
-      expect(itemProps.totalResults).toEqual(mockTotal);
-      expect(itemProps.title).toEqual(mockTitle);
-    })
+      it('calls helper methods with given resourceType', () => {
+        getSuggestedResultsForResourceSpy.mockClear();
+        getTotalResultsForResourceSpy.mockClear();
+        getTitleForResourceSpy.mockClear();
+        const givenResourceType = ResourceType.dashboard;
+        wrapper.instance().renderResultsByResource(givenResourceType);
+        expect(getSuggestedResultsForResourceSpy).toHaveBeenCalledWith(givenResourceType);
+        expect(getTotalResultsForResourceSpy).toHaveBeenCalledWith(givenResourceType);
+        expect(getTitleForResourceSpy).toHaveBeenCalledWith(givenResourceType);
+      });
+
+      it('renders ResultItemList with expected props', () => {
+        const givenResourceType = ResourceType.dashboard;
+        const content = shallow(wrapper.instance().renderResultsByResource(givenResourceType));
+        const item = content.find('.inline-results-section').find(ResultItemList);
+        const itemProps = item.props();
+        expect(itemProps.onItemSelect).toEqual(props.onItemSelect);
+        expect(itemProps.resourceType).toEqual(givenResourceType);
+        expect(itemProps.suggestedResults).toEqual(mockResults);
+        expect(itemProps.totalResults).toEqual(mockTotal);
+        expect(itemProps.title).toEqual(mockTitle);
+      });
+    });
   });
 
   describe('renderResults', () => {
@@ -358,10 +384,9 @@ describe('InlineSearchResults', () => {
       wrapper.update();
     });
 
-    it('renders a LoadingSpinner when props.isLoading', () => {
+    it('does not render anything when props.isLoading', () => {
       const wrapper = setup({isLoading: true}).wrapper;
-      const content = shallow(wrapper.instance().renderResults());
-      expect(content.find(LoadingSpinner).exists()).toBe(true);
+      expect(wrapper.instance().renderResults()).toBe(null);
     });
 
     describe('when !props.isLoading', () => {

--- a/amundsen_application/static/js/fixtures/search/inlineResults.ts
+++ b/amundsen_application/static/js/fixtures/search/inlineResults.ts
@@ -14,6 +14,20 @@ export const isLoadingExample = {
   },
 };
 
+export const noResultsExample = {
+  isLoading: false,
+  tables: {
+    page_index: 0,
+    results: [],
+    total_results: 0,
+  },
+  users: {
+    page_index: 0,
+    results: [],
+    total_results: 0,
+  },
+};
+
 export const allResourcesExample = {
   isLoading: false,
   tables: {


### PR DESCRIPTION
### Summary of Changes
This PR covers changes from our Design QA on the inline results feature. Changes include:
1. When the search is occurring `InlineSearchResults` no longer shows the large `LoadingSpinner` in place of the results. Instead `SearchItem` will show a small `LoadingSpinner` instead.
2. When there are no results for a particular resource, the `ResultItemList` for that resource will not be rendered. Instead `SearchItem` will show "No results found" for that resource. 
3. Minor css changes regarding the spacing of the items in `InlineSearchResults`.

![inline_search](https://user-images.githubusercontent.com/1790900/70196136-9f454080-16bc-11ea-9d8c-0d0aa6b6047a.gif)

#### Worthy Mentions
1. The above items required connecting `SearchItem` to the application state so that it can get the inlineResults state.
2. `mapStateToProps` tests for `SearchItem` takes a new approach that I intend to carry forward. It is based on importing test fixtures, and verifying the props are mapped based on what we expect for that fixture. This approach avoids tightly coupling the tests with the exact transformation logic that we execute in `mapStateToProps`.

### Tests

Updated tests according to  modifications.

### Documentation

No documentation needed for these UI modifications.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
