### PR TITLE
Consolidate look&feel of request/feedback forms

### DIFF
--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/BugReportFeedbackForm/index.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/BugReportFeedbackForm/index.tsx
@@ -21,7 +21,7 @@ export class BugReportFeedbackForm extends AbstractFeedbackForm {
   constructor(props) {
     super(props);
   }
-  
+
   renderCustom() {
     return (
       <form id={AbstractFeedbackForm.FORM_ID} onSubmit={ this.submitForm }>
@@ -40,7 +40,7 @@ export class BugReportFeedbackForm extends AbstractFeedbackForm {
           <textarea name="repro-steps" className="form-control" rows={5} required={ true }
                     maxLength={ 2000 } placeholder={REPRO_STEPS_PLACEHOLDER}/>
         </div>
-        <button className="btn btn-default submit" type="submit">{SUBMIT_TEXT}</button>
+        <button className="btn btn-primary" type="submit">{SUBMIT_TEXT}</button>
       </form>
     );
   }

--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/BugReportFeedbackForm/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/BugReportFeedbackForm/tests/index.spec.tsx
@@ -106,7 +106,7 @@ describe('BugReportFeedbackForm', () => {
 
     it('renders submit button with correct props', () => {
       expect(form.find('button').props()).toMatchObject({
-        className: 'btn btn-default submit',
+        className: 'btn btn-primary',
         type: 'submit',
       });
     });

--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/RatingFeedbackForm/index.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/RatingFeedbackForm/index.tsx
@@ -19,7 +19,7 @@ export class RatingFeedbackForm extends AbstractFeedbackForm {
   constructor(props) {
     super(props);
   }
-  
+
   renderCustom() {
     const ratings = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     const radioButtonSet = ratings.map(rating => (
@@ -46,7 +46,7 @@ export class RatingFeedbackForm extends AbstractFeedbackForm {
         </div>
         <textarea className="form-control form-group" name="comment" form={AbstractFeedbackForm.FORM_ID}
           rows={ 8 } maxLength={ 2000 } placeholder={COMMENTS_PLACEHOLDER}/>
-        <button className="btn btn-default submit" type="submit">{SUBMIT_TEXT}</button>
+        <button className="btn btn-primary" type="submit">{SUBMIT_TEXT}</button>
       </form>
     );
   }

--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/RatingFeedbackForm/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/RatingFeedbackForm/tests/index.spec.tsx
@@ -110,7 +110,7 @@ describe('RatingFeedbackForm', () => {
 
     it('renders submit button with correct props as fourth child', () => {
       expect(form.children().at(3).find('button').props()).toMatchObject({
-        className: 'btn btn-default submit',
+        className: 'btn btn-primary',
         type: 'submit',
       });
     });

--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/RequestFeedbackForm/index.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/RequestFeedbackForm/index.tsx
@@ -21,7 +21,7 @@ export class RequestFeedbackForm extends AbstractFeedbackForm {
   constructor(props) {
     super(props);
   }
-  
+
   renderCustom() {
     return (
       <form id={AbstractFeedbackForm.FORM_ID} onSubmit={ this.submitForm }>
@@ -40,7 +40,7 @@ export class RequestFeedbackForm extends AbstractFeedbackForm {
           <textarea name="value-prop" className="form-control" rows={5} required={ true }
                     maxLength={ 2000 } placeholder={PROPOSITION_PLACEHOLDER} />
         </div>
-        <button className="btn btn-default submit" type="submit">{SUBMIT_TEXT}</button>
+        <button className="btn btn-primary" type="submit">{SUBMIT_TEXT}</button>
       </form>
     );
   }

--- a/amundsen_application/static/js/components/Feedback/FeedbackForm/RequestFeedbackForm/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/Feedback/FeedbackForm/RequestFeedbackForm/tests/index.spec.tsx
@@ -106,7 +106,7 @@ describe('RequestFeedbackForm', () => {
 
     it('renders submit button with correct props', () => {
       expect(form.find('button').props()).toMatchObject({
-        className: 'btn btn-default submit',
+        className: 'btn btn-primary',
         type: 'submit',
       });
     });

--- a/amundsen_application/static/js/components/Feedback/index.tsx
+++ b/amundsen_application/static/js/components/Feedback/index.tsx
@@ -80,9 +80,9 @@ export default class Feedback extends React.Component<FeedbackProps, FeedbackSta
             this.state.isOpen &&
             <div className="feedback-component">
               <div className="feedback-header">
-                <div className="title">
-                  {this.props.title.toUpperCase()}
-                </div>
+                <h3 className="title">
+                  {this.props.title}
+                </h3>
                 <button type="button" className="btn btn-close" aria-label={BUTTON_CLOSE_TEXT} onClick={this.toggle} />
               </div>
               <div className="text-center">

--- a/amundsen_application/static/js/components/Feedback/styles.scss
+++ b/amundsen_application/static/js/components/Feedback/styles.scss
@@ -40,32 +40,20 @@
 
   color: $text-primary;
 
-  .title {
-    color: $text-secondary;
-    flex-grow: 1;
-    font-size: 12px;
-    font-family: $font-family-header;
-    font-weight: $font-weight-header-regular;
-    height: 24px;
-    line-height: 32px;
-  }
-
   .feedback-header {
     display: flex;
     margin-bottom: 8px;
+    .title {
+      flex-grow: 1;
+    }
+
+    button {
+      margin: auto 0;
+    }
   }
 
   .btn-group {
     margin: 8px auto 16px;
-  }
-
-  .submit {
-    float: right;
-    margin-top: 16px;
-  }
-
-  .submit:hover {
-    background-color: $gray-lighter;
   }
 
   .radio-set {

--- a/amundsen_application/static/js/components/Feedback/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/Feedback/tests/index.spec.tsx
@@ -120,7 +120,7 @@ describe('Feedback', () => {
           button = header.children().at(1);
         });
         it('renders correct title', () => {
-          expect(title.text()).toEqual(props.title.toUpperCase());
+          expect(title.text()).toEqual(props.title);
         });
 
         it('renders close button with correct props', () => {

--- a/amundsen_application/static/js/components/TableDetail/RequestMetadataForm/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/RequestMetadataForm/styles.scss
@@ -22,6 +22,10 @@
 
     .request-header {
       display: flex;
+
+      button {
+        margin: auto 0;
+      }
     }
 
     .select-label {


### PR DESCRIPTION
### Summary of Changes

This PR covers a cleanup task to unify the look and feel of our "pop-up" forms, `RequestMetadataForm` and `FeedbackForm`. Design requested:
1. Match title style of the request form
2. Match button style of the request form, and left align with form instead of right
3. Make sure the cancel/close icon matches in style and position

![image](https://user-images.githubusercontent.com/1790900/71042169-e16c7a00-20df-11ea-8f0c-bed3873ae60c.png)

### Tests

Tests updated as needed based on component changes.

### Documentation

N/A. Just UI improvements.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
