### PR TITLE
Handle get bookmark failure properly

### DIFF
--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -445,10 +445,16 @@ def get_bookmark() -> Response:
         response = request_metadata(url=url, method=request.method)
         status_code = response.status_code
 
-        tables = response.json().get('table')
-        table_bookmarks = [marshall_table_partial(table) for table in tables]
+        if status_code == HTTPStatus.OK:
+            message = 'Success'
+            tables = response.json().get('table')
+            table_bookmarks = [marshall_table_partial(table) for table in tables]
+        else:
+            message = f'Encountered error: failed to get bookmark for user_id: {user_id}'
+            logging.error(message)
+            table_bookmarks = []
 
-        return make_response(jsonify({'msg': 'success', 'bookmarks': table_bookmarks}), status_code)
+        return make_response(jsonify({'msg': message, 'bookmarks': table_bookmarks}), status_code)
     except Exception as e:
         message = 'Encountered exception: ' + str(e)
         logging.exception(message)

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -592,6 +592,20 @@ class MetadataTest(unittest.TestCase):
             self.assertCountEqual(data.get('bookmarks'), self.expected_parsed_user_resources)
 
     @responses.activate
+    def test_get_bookmark_failure(self) -> None:
+        """
+        Test correct response returned when get_bookmark fails
+        """
+        url = f"{local_app.config['METADATASERVICE_BASE']}{USER_ENDPOINT}/{TEST_USER_ID}/follow/"
+        responses.add(responses.GET, url, json=self.mock_user, status=HTTPStatus.BAD_REQUEST)
+
+        with local_app.test_client() as test:
+            response = test.get('/api/metadata/v0/user/bookmark')
+            self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+            expected = {'bookmarks': [], 'msg': 'Encountered error: failed to get bookmark for user_id: test_user_id'}
+            self.assertEqual(response.json, expected)
+
+    @responses.activate
     def test_get_bookmark_for_user(self) -> None:
         """
         Test get_bookmark with a specified user


### PR DESCRIPTION
### Summary of Changes

This PR properly handles failed `get_bookmarks` requests

### Tests

I added a test to check this failure state

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
