### PR TITLE
Lower python coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = NONE
 max-line-length = 120
 
 [tool:pytest]
-addopts = --cov=amundsen_application --cov-fail-under=75 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
+addopts = --cov=amundsen_application --cov-fail-under=70 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
### Summary of Changes

This should fix the master build. We raised the coverage threshold in a previous PR, but it's not giving enough buffer -- we expect coverage to naturally go up/down within a couple percentage points during regular development even when folks are still covering important logic.

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
