### PR TITLE
Add support for configurable filter section help text

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/FilterSection/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/FilterSection/index.tsx
@@ -5,9 +5,12 @@ import { clearFilterByCategory } from 'ducks/search/filters/reducer';
 
 import { CLEAR_BTN_TEXT } from '../constants';
 
+import InfoButton from 'components/common/InfoButton';
+
 export interface OwnProps {
   categoryId: string;
   hasValue: boolean;
+  helpText?: string;
   title: string;
 };
 
@@ -23,11 +26,21 @@ export class FilterSection extends React.Component<FilterSectionProps> {
   }
 
   render = () => {
-    const { title, hasValue, onClearFilter, children } = this.props;
+    const { title, hasValue, helpText, onClearFilter, children } = this.props;
     return (
       <div className="search-filter-section">
         <div className="search-filter-section-header">
-          <div className="title-2">{ title }</div>
+          <div className="search-filter-section-title">
+            <div className="title-2">{ title }</div>
+            {
+              helpText &&
+              <InfoButton
+                infoText={ helpText }
+                placement="top"
+                size="small"
+              />
+            }
+          </div>
           {
             hasValue &&
             <a onClick={ onClearFilter } className='btn btn-flat-icon'>

--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/index.tsx
@@ -16,6 +16,7 @@ import './styles.scss'
 
 interface CheckboxFilterSection {
   categoryId: string;
+  helpText?: string;
   properties: CheckboxFilterProperties[];
   title: string;
 }
@@ -40,7 +41,7 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
   }
 
   createCheckBoxSection = (key: string, section: CheckboxFilterSection) => {
-    const { categoryId, properties, title } = section;
+    const { categoryId, helpText, properties, title } = section;
     let hasChecked = false;
     properties.forEach((item) => {
       if (item.checked) {
@@ -52,6 +53,7 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
         key={key}
         categoryId={ categoryId }
         hasValue={ hasChecked }
+        helpText={ helpText }
         title={ title }
       >
         <CheckBoxFilter
@@ -120,6 +122,7 @@ export const mapStateToProps = (state: GlobalState) => {
         checkBoxSections.push({
           title: categoryConfig.displayName,
           categoryId: categoryConfig.value,
+          helpText: categoryConfig.helpText,
           properties: categoryConfig.options.map((option) => {
             return {
               value: option.value,
@@ -137,7 +140,7 @@ export const mapStateToProps = (state: GlobalState) => {
       if (categoryConfig.type === FilterType.SINGLE_VALUE) {
         inputSections.push({
           categoryId: categoryConfig.value,
-          helpText: categoryConfig.helpText || '',
+          helpText: categoryConfig.helpText,
           title: categoryConfig.displayName,
           value: currentFilterValue,
         });

--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/index.tsx
@@ -22,6 +22,7 @@ interface CheckboxFilterSection {
 
 interface InputFilterSection {
   categoryId: string;
+  helpText?: string;
   title: string;
   value: string;
 }
@@ -62,12 +63,13 @@ export class SearchFilter extends React.Component<SearchFilterProps> {
   };
 
   createInputSection = (key: string, section: InputFilterSection) => {
-    const { categoryId, title, value } = section;
+    const { categoryId, helpText, title, value } = section;
     return (
       <FilterSection
         key={key}
         categoryId={ categoryId }
         hasValue={ value && value.length > 0 }
+        helpText={ helpText }
         title={ title }
       >
         <InputFilter
@@ -135,6 +137,7 @@ export const mapStateToProps = (state: GlobalState) => {
       if (categoryConfig.type === FilterType.SINGLE_VALUE) {
         inputSections.push({
           categoryId: categoryConfig.value,
+          helpText: categoryConfig.helpText || '',
           title: categoryConfig.displayName,
           value: currentFilterValue,
         });

--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/styles.scss
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/styles.scss
@@ -8,8 +8,13 @@
   .search-filter-section-header {
     display: flex;
 
-    .title-2 {
+    .search-filter-section-title {
+      display: flex;
       flex-grow: 1;
+
+      button {
+        margin: auto 4px;
+      }
     }
   }
 

--- a/amundsen_application/static/js/config/config-default.ts
+++ b/amundsen_application/static/js/config/config-default.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from './config-types';
 
-import { FilterType, ResourceType } from '../interfaces';
+import { ResourceType } from '../interfaces';
 
 const configDefault: AppConfig = {
   badges: {},
@@ -65,40 +65,6 @@ const configDefault: AppConfig = {
           iconClass: 'icon-redshift',
         },
       },
-      filterCategories: [
-        {
-          value: 'database',
-          displayName: 'Source',
-          type: FilterType.MULTI_SELECT_VALUE,
-          options: [
-            { value: 'bigquery', displayName: 'BigQuery' },
-            { value: 'hive', displayName: 'Hive' },
-            { value: 'postgres', displayName: 'Postgres' },
-            { value: 'presto', displayName: 'Presto' },
-            { value: 'redshift', displayName: 'Redshift' },
-          ],
-        },
-        {
-          value: 'column',
-          displayName: 'Column',
-          type: FilterType.SINGLE_VALUE,
-        },
-        {
-          value: 'schema',
-          displayName: 'Schema',
-          type: FilterType.SINGLE_VALUE,
-        },
-        {
-          value: 'table',
-          displayName: 'Table',
-          type: FilterType.SINGLE_VALUE,
-        },
-        {
-          value: 'tag',
-          displayName: 'Tag',
-          type: FilterType.SINGLE_VALUE,
-        },
-      ]
     },
     [ResourceType.user]: {
       displayName: 'People'

--- a/amundsen_application/static/js/config/config-default.ts
+++ b/amundsen_application/static/js/config/config-default.ts
@@ -69,26 +69,31 @@ const configDefault: AppConfig = {
         {
           value: 'database',
           displayName: 'Source',
+          helpText: 'Enter exact database name or a regex wildcard pattern',
           type: FilterType.SINGLE_VALUE,
         },
         {
           value: 'column',
           displayName: 'Column',
+          helpText: 'Enter exact column name or a regex wildcard pattern',
           type: FilterType.SINGLE_VALUE,
         },
         {
           value: 'schema',
           displayName: 'Schema',
+          helpText: 'Enter exact schema name or a regex wildcard pattern',
           type: FilterType.SINGLE_VALUE,
         },
         {
           value: 'table',
           displayName: 'Table',
+          helpText: 'Enter exact table name or a regex wildcard pattern',
           type: FilterType.SINGLE_VALUE,
         },
         {
           value: 'tag',
           displayName: 'Tag',
+          helpText: 'Enter exact tag name or a regex wildcard pattern',
           type: FilterType.SINGLE_VALUE,
         },
       ]

--- a/amundsen_application/static/js/config/config-default.ts
+++ b/amundsen_application/static/js/config/config-default.ts
@@ -1,6 +1,6 @@
 import { AppConfig } from './config-types';
 
-import { ResourceType } from '../interfaces';
+import { FilterType, ResourceType } from '../interfaces';
 
 const configDefault: AppConfig = {
   badges: {},
@@ -65,6 +65,33 @@ const configDefault: AppConfig = {
           iconClass: 'icon-redshift',
         },
       },
+      filterCategories: [
+        {
+          value: 'database',
+          displayName: 'Source',
+          type: FilterType.SINGLE_VALUE,
+        },
+        {
+          value: 'column',
+          displayName: 'Column',
+          type: FilterType.SINGLE_VALUE,
+        },
+        {
+          value: 'schema',
+          displayName: 'Schema',
+          type: FilterType.SINGLE_VALUE,
+        },
+        {
+          value: 'table',
+          displayName: 'Table',
+          type: FilterType.SINGLE_VALUE,
+        },
+        {
+          value: 'tag',
+          displayName: 'Tag',
+          type: FilterType.SINGLE_VALUE,
+        },
+      ]
     },
     [ResourceType.user]: {
       displayName: 'People'

--- a/amundsen_application/static/js/config/config-types.ts
+++ b/amundsen_application/static/js/config/config-types.ts
@@ -64,6 +64,7 @@ interface MultiSelectFilterOptions {
 }
 
 interface BaseFilterCategory {
+  helpText?: string;
   value: string;
   displayName: string;
   type: FilterType;


### PR DESCRIPTION
### Summary of Changes

We want to offer some optional help text for each filter section. This has been added to the optional `filterCategories` configuration, and if present will result in an `InfoButton` in the filter section header -- exact text will likely still go through some iteration in design qa

<img src='https://user-images.githubusercontent.com/1790900/73041385-1754fa80-3e12-11ea-91c8-3a9a71e0b38a.png' width='50%' />

### Tests

TODO: As part of final feature branch review

### Documentation

TODO: As part of final feature branch review

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
