### PR TITLE
Rename optional_data to options for mail client

### DIFF
--- a/amundsen_application/api/mail/v0.py
+++ b/amundsen_application/api/mail/v0.py
@@ -50,7 +50,7 @@ def feedback() -> Response:
             'form_data': data
         }
 
-        response = mail_client.send_email(html=html_content, subject=subject, optional_data=options)
+        response = mail_client.send_email(html=html_content, subject=subject, options=options)
         status_code = response.status_code
 
         if status_code == HTTPStatus.OK:

--- a/amundsen_application/api/utils/notification_utils.py
+++ b/amundsen_application/api/utils/notification_utils.py
@@ -194,7 +194,7 @@ def send_notification(*, notification_type: str, options: Dict, recipients: List
         response = mail_client.send_email(
             html=html,
             subject=subject,
-            optional_data={
+            options={
                 'email_type': notification_type,
             },
             recipients=recipients,

--- a/amundsen_application/base/base_mail_client.py
+++ b/amundsen_application/base/base_mail_client.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from flask import Response
 
@@ -13,14 +13,14 @@ class BaseMailClient(abc.ABC):
     def send_email(self,
                    html: str,
                    subject: str,
-                   optional_data: Dict,
+                   options: Optional[Dict],
                    recipients: List[str],
                    sender: str) -> Response:
         """
         Sends an email using the following parameters
         :param html: HTML email content
         :param subject: The subject of the email
-        :param optional_data: A dictionary of any values needed for custom implementations
+        :param options: An optional dictionary of any values needed for custom implementations
         :param recipients: A list of recipients for the email
         :param sender: The sending address associated with the email
         :return:

--- a/amundsen_application/base/examples/example_mail_client.py
+++ b/amundsen_application/base/examples/example_mail_client.py
@@ -5,7 +5,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from http import HTTPStatus
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from flask import Response, jsonify, make_response
 
@@ -20,7 +20,7 @@ class MailClient(BaseMailClient):
     def send_email(self,
                    html: str,
                    subject: str,
-                   options: Dict = None,
+                   options: Optional[Dict] = None,
                    recipients: List[str] = None,
                    sender: str = None) -> Response:
         if not sender:

--- a/amundsen_application/base/examples/example_mail_client.py
+++ b/amundsen_application/base/examples/example_mail_client.py
@@ -20,7 +20,7 @@ class MailClient(BaseMailClient):
     def send_email(self,
                    html: str,
                    subject: str,
-                   optional_data: Dict = None,
+                   options: Dict = None,
                    recipients: List[str] = None,
                    sender: str = None) -> Response:
         if not sender:

--- a/tests/unit/api/mail/test_v0.py
+++ b/tests/unit/api/mail/test_v0.py
@@ -21,7 +21,7 @@ class MockMailClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   optional_data: Dict = {}) -> Response:
+                   options: Dict = {}) -> Response:
         return make_response(jsonify({}), self.status_code)
 
 
@@ -35,7 +35,7 @@ class MockBadClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   optional_data: Dict = {}) -> Response:
+                   options: Dict = {}) -> Response:
         raise Exception('Bad client')
 
 

--- a/tests/unit/utils/notification/test_utils.py
+++ b/tests/unit/utils/notification/test_utils.py
@@ -26,7 +26,7 @@ class MockMailClient(BaseMailClient):
                    subject: str = None,
                    text: str = None,
                    html: str = None,
-                   optional_data: Dict = {}) -> Response:
+                   options: Dict = {}) -> Response:
         return make_response(jsonify({}), self.status_code)
 
 
@@ -374,7 +374,7 @@ class NotificationUtilsTest(unittest.TestCase):
             mock_client.send_email.assert_called_with(
                 html=mock_html,
                 subject=mock_subject,
-                optional_data={'email_type': test_notification_type},
+                options={'email_type': test_notification_type},
                 recipients=expected_recipients,
                 sender=test_sender
             )


### PR DESCRIPTION
### Summary of Changes

Rename `optional_data` on `base_mail_client` to `options`. This is simply a more succinct name and should be called out in the 2.0.0 release as folks will need to update their existing mail client implementations.

### Tests

N/A. Existing tests passing is sufficient.

### Documentation

Updated docstring. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
