### PR TITLE
Update search results to include badges and display them

### DIFF
--- a/amundsen_application/api/search/v0.py
+++ b/amundsen_application/api/search/v0.py
@@ -3,7 +3,7 @@ import json
 
 from http import HTTPStatus
 
-from typing import Any, Dict, Optional  # noqa: F401
+from typing import Any, Dict  # noqa: F401
 
 from flask import Response, jsonify, make_response, request
 from flask import current_app as app

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -1,8 +1,4 @@
-import logging
-
 from typing import Dict, List  # noqa: F401
-
-LOGGER = logging.getLogger(__name__)
 
 
 # These can move to a configuration when we have custom use cases outside of these default values

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -20,7 +20,7 @@ def map_table_result(result: Dict) -> Dict:
         'description': result.get('description', None),
         'database': result.get('database', None),
         'schema': result.get('schema', None),
-        'badges': _map_badges(result.get('badges', None)),
+        'badges': result.get('badges', None),
         'last_updated_timestamp': result.get('last_updated_timestamp', None),
     }
 
@@ -54,8 +54,3 @@ def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str
         'query_term': search_term
     }
 
-
-def _map_badges(badges: List[str]) -> List[Dict[str, str]]:
-    if not badges:
-        return []
-    return [{"tag_name": badge, "tag_type": "badge"} for badge in badges]

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -53,4 +53,3 @@ def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str
         },
         'query_term': search_term
     }
-

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -1,10 +1,14 @@
+import logging
+
 from typing import Dict, List  # noqa: F401
+
+LOGGER = logging.getLogger(__name__)
+
 
 # These can move to a configuration when we have custom use cases outside of these default values
 valid_search_fields = {
     'column',
     'database',
-    'badge',
     'schema',
     'table',
     'tag'

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -4,6 +4,7 @@ from typing import Dict, List  # noqa: F401
 valid_search_fields = {
     'column',
     'database',
+    'badge',
     'schema',
     'table',
     'tag'
@@ -19,6 +20,7 @@ def map_table_result(result: Dict) -> Dict:
         'description': result.get('description', None),
         'database': result.get('database', None),
         'schema': result.get('schema', None),
+        'badges': _map_badges(result.get('badges', None)),
         'last_updated_timestamp': result.get('last_updated_timestamp', None),
     }
 
@@ -51,3 +53,9 @@ def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str
         },
         'query_term': search_term
     }
+
+
+def _map_badges(badges: List[str]) -> List[Dict[str, str]]:
+    if not badges:
+        return []
+    return [{"tag_name": badge, "tag_type": "badge"} for badge in badges]

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
@@ -9,6 +9,7 @@ import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 
 import { getDatabaseDisplayName, getDatabaseIconClass } from 'config/config-utils';
 import { formatDate } from 'utils/dateUtils';
+import BadgeList from 'components/common/BadgeList';
 
 export interface TableListItemProps {
   table: TableResource;
@@ -53,11 +54,10 @@ class TableListItem extends React.Component<TableListItemProps, {}> {
           </div>
           <div className="resource-badges">
             {
-              !!table.last_updated_timestamp &&
+              !!table.badges && table.badges.length > 0 && 
               <div>
-                <div className="title-3">Last Updated</div>
                 <div className="body-secondary-3">
-                  { formatDate({ epochTimestamp: table.last_updated_timestamp }) }
+                <BadgeList badges={ table.badges } />
                 </div>
               </div>
             }

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -33,7 +33,7 @@ describe('TableListItem', () => {
         description: 'I am the description',
         key: '',
         last_updated_timestamp: 1553829681,
-        badges: [ { tag_name: "badgeName", tag_type: TagType.BADGE } ],
+        badges: [ { tag_name: 'badgeName', tag_type: TagType.BADGE } ],
         name: 'tableName',
         schema: 'tableSchema',
       },

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -5,10 +5,10 @@ import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 import TableListItem, { TableListItemProps } from '../';
-import { ResourceType } from 'interfaces';
+import { ResourceType, Badge, TagType } from 'interfaces';
 
 import * as ConfigUtils from 'config/config-utils';
-import { formatDate } from 'utils/dateUtils';
+import BadgeList from 'components/common/BadgeList';
 
 const MOCK_DISPLAY_NAME = 'displayName';
 const MOCK_ICON_CLASS = 'test-class';
@@ -33,6 +33,7 @@ describe('TableListItem', () => {
         description: 'I am the description',
         key: '',
         last_updated_timestamp: 1553829681,
+        badges: [ { tag_name: "badgeName", tag_type: TagType.BADGE } ],
         name: 'tableName',
         schema: 'tableSchema',
       },
@@ -126,26 +127,36 @@ describe('TableListItem', () => {
         expect(resourceBadges.exists()).toBe(true);
       });
 
-      describe('if props.table has last_updated_timestamp', () => {
-        it('renders Last Updated title', () => {
-          expect(resourceBadges.children().at(0).children().at(0).text()).toEqual('Last Updated');
-        });
-
-        it('renders getDateLabel value', () => {
-          const expectedString = formatDate({ epochTimestamp: props.table.last_updated_timestamp });
-          expect(resourceBadges.children().at(0).children().at(1).text()).toEqual(expectedString);
+      describe('if props.table has badges', () => {
+      
+        it('renders flag for badge', () => {
+          expect(resourceBadges.find(BadgeList).exists()).toBe(true);
         });
       });
 
-      describe('if props.table does not have last_updated_timestamp', () => {
-        it('does not render Last Updated section', () => {
+      describe('if props.table does not have badges', () => {
+        it('does not render badges section', () => {
           const { props, wrapper } = setup({ table: {
             type: ResourceType.table,
             cluster: '',
             database: '',
             description: 'I am the description',
             key: '',
-            last_updated_timestamp: null,
+            badges: null, 
+            name: 'tableName',
+            schema: 'tableSchema',
+          }});
+          expect(wrapper.find('.resource-badges').children()).toHaveLength(1);
+        });
+
+        it('or if they are empty does not render badges section', () => {
+          const { props, wrapper } = setup({ table: {
+            type: ResourceType.table,
+            cluster: '',
+            database: '',
+            description: 'I am the description',
+            key: '',
+            badges: [], 
             name: 'tableName',
             schema: 'tableSchema',
           }});

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -128,9 +128,8 @@ describe('TableListItem', () => {
       });
 
       describe('if props.table has badges', () => {
-      
-        it('renders flag for badge', () => {
-          expect(resourceBadges.find(BadgeList).exists()).toBe(true);
+        it('renders BadgeList for badges', () => {
+          expect(resourceBadges.find(BadgeList).props().badges).toEqual(props.table.badges);
         });
       });
 

--- a/amundsen_application/static/js/interfaces/Resources.ts
+++ b/amundsen_application/static/js/interfaces/Resources.ts
@@ -1,4 +1,5 @@
 import { PeopleUser } from './User';
+import { Badge } from './Tags';
 
 export enum ResourceType {
   table = "table",
@@ -28,6 +29,7 @@ export interface TableResource extends Resource {
   last_updated_timestamp?: number;
   name: string;
   schema: string;
+  badges?: Badge[];  
 };
 
 export interface UserResource extends Resource, PeopleUser {

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -27,6 +27,7 @@ MOCK_TABLE_RESULTS = {
             'name': 'test_table',
             'schema': 'test_schema',
             'tags': [],
+            'badges': []
         }
     ]
 }
@@ -41,6 +42,7 @@ MOCK_PARSED_TABLE_RESULTS = [
         'last_updated_timestamp': 1527283287,
         'name': 'test_table',
         'schema': 'test_schema',
+        'badges': []
     }
 ]
 


### PR DESCRIPTION
### Summary of Changes

Some tables have badges which are displayed on the table detail view page. These badges contain useful information that can help users determine which table they want to look at. This change surfaces that information on search. 

### Tests

Modified tests to confirm that the results are displayed

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
