### PR TITLE
Update search_table endpoint

### DIFF
--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -51,3 +51,10 @@ def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str
         },
         'query_term': search_term
     }
+
+
+def has_filters(*, filters: Dict = {}) -> bool:
+    for category in valid_search_fields:
+        if filters.get(category) is not None:
+            return True
+    return False

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -130,8 +130,7 @@ class SearchTable(unittest.TestCase):
     @patch('amundsen_application.api.search.v0.generate_query_json')
     def test_does_not_calls_generate_query_json(self, mock_generate_query_json, has_filters_mock) -> None:
         """
-        Test generate_query_json helper method is called with correct arguments
-        from the request_json if filters exist
+        Test generate_query_json helper method is not called if filters do not exist
         :return:
         """
         test_term = 'hello'

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -6,7 +6,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from amundsen_application import create_app
-from amundsen_application.api.search.v0 import SEARCH_TABLE_ENDPOINT, SEARCH_USER_ENDPOINT
+from amundsen_application.api.search.v0 import SEARCH_TABLE_ENDPOINT, SEARCH_TABLE_FILTER_ENDPOINT, SEARCH_USER_ENDPOINT
 
 local_app = create_app('amundsen_application.config.TestConfig', 'tests/templates')
 
@@ -45,11 +45,12 @@ MOCK_PARSED_TABLE_RESULTS = [
 ]
 
 
-class SearchTableQueryString(unittest.TestCase):
+class SearchTable(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_table_results = MOCK_TABLE_RESULTS
         self.expected_parsed_table_results = MOCK_PARSED_TABLE_RESULTS
         self.search_service_url = local_app.config['SEARCHSERVICE_BASE'] + SEARCH_TABLE_ENDPOINT
+        self.search_service_filter_url = local_app.config['SEARCHSERVICE_BASE'] + SEARCH_TABLE_FILTER_ENDPOINT
         self.fe_flask_endpoint = '/api/search/v0/table'
 
     def test_fail_if_term_is_none(self) -> None:
@@ -82,7 +83,10 @@ class SearchTableQueryString(unittest.TestCase):
         test_term = 'hello'
         test_index = 1
         test_search_type = 'test'
-        responses.add(responses.POST, self.search_service_url, json=self.mock_table_results, status=HTTPStatus.OK)
+        responses.add(responses.POST,
+                      self.search_service_filter_url,
+                      json=self.mock_table_results,
+                      status=HTTPStatus.OK)
 
         with local_app.test_client() as test:
             test.post(self.fe_flask_endpoint,
@@ -97,17 +101,22 @@ class SearchTableQueryString(unittest.TestCase):
                                                  search_type=test_search_type)
 
     @responses.activate
+    @patch('amundsen_application.api.search.v0.has_filters')
     @patch('amundsen_application.api.search.v0.generate_query_json')
-    def test_calls_generate_query_json(self, mock_generate_query_json) -> None:
+    def test_calls_generate_query_json(self, mock_generate_query_json, has_filters_mock) -> None:
         """
         Test generate_query_json helper method is called with correct arguments
-        from the request_json
+        from the request_json if filters exist
         :return:
         """
         test_filters = {'schema': 'test_schema'}
         test_term = 'hello'
         test_index = 1
-        responses.add(responses.POST, self.search_service_url, json=self.mock_table_results, status=HTTPStatus.OK)
+        responses.add(responses.POST,
+                      self.search_service_filter_url,
+                      json=self.mock_table_results,
+                      status=HTTPStatus.OK)
+        has_filters_mock.return_value = True
 
         with local_app.test_client() as test:
             test.post(self.fe_flask_endpoint,
@@ -115,6 +124,24 @@ class SearchTableQueryString(unittest.TestCase):
             mock_generate_query_json.assert_called_with(filters=test_filters,
                                                         page_index=test_index,
                                                         search_term=test_term)
+
+    @responses.activate
+    @patch('amundsen_application.api.search.v0.has_filters')
+    @patch('amundsen_application.api.search.v0.generate_query_json')
+    def test_does_not_calls_generate_query_json(self, mock_generate_query_json, has_filters_mock) -> None:
+        """
+        Test generate_query_json helper method is called with correct arguments
+        from the request_json if filters exist
+        :return:
+        """
+        test_term = 'hello'
+        test_index = 1
+        responses.add(responses.GET, self.search_service_url, json=self.mock_table_results, status=HTTPStatus.OK)
+        has_filters_mock.return_value = False
+
+        with local_app.test_client() as test:
+            test.post(self.fe_flask_endpoint, json={'term': test_term, 'pageIndex': test_index, 'filters': {}})
+            mock_generate_query_json.assert_not_called()
 
     @patch('amundsen_application.api.search.v0.generate_query_json')
     def test_catch_exception_generate_query_json(self, mock_generate_query_json) -> None:
@@ -144,7 +171,10 @@ class SearchTableQueryString(unittest.TestCase):
         test_filters = {'schema': 'test_schema'}
         test_term = 'hello'
         test_index = 1
-        responses.add(responses.POST, self.search_service_url, json=self.mock_table_results, status=HTTPStatus.OK)
+        responses.add(responses.POST,
+                      self.search_service_filter_url,
+                      json=self.mock_table_results,
+                      status=HTTPStatus.OK)
 
         with local_app.test_client() as test:
             response = test.post(self.fe_flask_endpoint,
@@ -165,7 +195,7 @@ class SearchTableQueryString(unittest.TestCase):
         test_filters = {'schema': 'test_schema'}
         test_term = 'hello'
         test_index = 1
-        responses.add(responses.POST, self.search_service_url, json={}, status=HTTPStatus.BAD_REQUEST)
+        responses.add(responses.POST, self.search_service_filter_url, json={}, status=HTTPStatus.BAD_REQUEST)
 
         with local_app.test_client() as test:
             response = test.post(self.fe_flask_endpoint,
@@ -175,7 +205,7 @@ class SearchTableQueryString(unittest.TestCase):
             self.assertEqual(data.get('msg'), 'Encountered error: Search request failed')
 
 
-class SearchUserTest(unittest.TestCase):
+class SearchUser(unittest.TestCase):
     def setUp(self) -> None:
         self.mock_search_user_results = {
             'total_results': 1,

--- a/tests/unit/utils/test_search_utils.py
+++ b/tests/unit/utils/test_search_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from amundsen_application.api.utils.search_utils import generate_query_json
+from amundsen_application.api.utils.search_utils import generate_query_json, has_filters
 
 
 class SearchUtilsTest(unittest.TestCase):
@@ -41,3 +41,19 @@ class SearchUtilsTest(unittest.TestCase):
             'filters': self.expected_transformed_filters
         })
         self.assertEqual(query_json.get('query_term'), self.test_term)
+
+    def test_has_filters_return_true(self) -> None:
+        """
+        Returns true if called with a dictionary that has values for a valid filter category
+        :return:
+        """
+        self.assertTrue(has_filters(filters=self.test_filters))
+
+    def test_has_filters_return_false(self) -> None:
+        """
+        Returns false if called with a dictionary that has no values for a valid filter category
+        :return:
+        """
+        test_filters = {'fake_category': {'db1': True}}
+        self.assertFalse(has_filters(filters=test_filters))
+        self.assertFalse(has_filters())


### PR DESCRIPTION
### Summary of Changes

This PR updates the Flask endpoint that calls the search service, such that if there are filters it will `POST` to the [SearchTableFilter API](https://github.com/lyft/amundsensearchlibrary/blob/master/search_service/api/table.py#L121) else maintain a `GET` to the [SearchTableAPI](https://github.com/lyft/amundsensearchlibrary/blob/master/search_service/api/table.py#L34)

### Tests

Updates tests according to changes.

### Documentation

N/A. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
