### PR TITLE
Add reporter for JIRA Issue Creation

### DIFF
--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -28,6 +28,19 @@ class Config:
     # Request Timeout Configurations in Seconds
     REQUEST_SESSION_TIMEOUT_SEC = 3
 
+    # Frontend Application
+    FRONTEND_BASE = ''
+
+    # Search Service
+    SEARCHSERVICE_REQUEST_CLIENT = None
+    SEARCHSERVICE_REQUEST_HEADERS = None
+    SEARCHSERVICE_BASE = ''
+
+    # Metadata Service
+    METADATASERVICE_REQUEST_CLIENT = None
+    METADATASERVICE_REQUEST_HEADERS = None
+    METADATASERVICE_BASE = ''
+
     # Mail Client Features
     MAIL_CLIENT = None
     NOTIFICATIONS_ENABLED = False
@@ -45,6 +58,15 @@ class Config:
     ISSUE_TRACKER_CLIENT_ENABLED = False  # type: bool
     # Max issues to display at a time
     ISSUE_TRACKER_MAX_RESULTS = None  # type: int
+
+    # If specified, will be used to generate headers for service-to-service communication
+    # Please note that if specified, this will ignore following config properties:
+    # 1. METADATASERVICE_REQUEST_HEADERS
+    # 2. SEARCHSERVICE_REQUEST_HEADERS
+    REQUEST_HEADERS_METHOD: Optional[Callable[[Flask], Optional[Dict]]] = None
+
+    AUTH_USER_METHOD: Optional[Callable[[Flask], User]] = None
+    GET_PROFILE_URL = None
 
 
 class LocalConfig(Config):
@@ -67,30 +89,17 @@ class LocalConfig(Config):
                                        PORT=FRONTEND_PORT)
                                    )
 
-    SEARCHSERVICE_REQUEST_CLIENT = None
-    SEARCHSERVICE_REQUEST_HEADERS = None
     SEARCHSERVICE_BASE = os.environ.get('SEARCHSERVICE_BASE',
                                         'http://{LOCAL_HOST}:{PORT}'.format(
                                             LOCAL_HOST=LOCAL_HOST,
                                             PORT=SEARCH_PORT)
                                         )
 
-    METADATASERVICE_REQUEST_CLIENT = None
-    METADATASERVICE_REQUEST_HEADERS = None
     METADATASERVICE_BASE = os.environ.get('METADATASERVICE_BASE',
                                           'http://{LOCAL_HOST}:{PORT}'.format(
                                               LOCAL_HOST=LOCAL_HOST,
                                               PORT=METADATA_PORT)
                                           )
-
-    # If specified, will be used to generate headers for service-to-service communication
-    # Please note that if specified, this will ignore following config properties:
-    # 1. METADATASERVICE_REQUEST_HEADERS
-    # 2. SEARCHSERVICE_REQUEST_HEADERS
-    REQUEST_HEADERS_METHOD: Optional[Callable[[Flask], Optional[Dict]]] = None
-
-    AUTH_USER_METHOD: Optional[Callable[[Flask], User]] = None
-    GET_PROFILE_URL = None
 
 
 class TestConfig(LocalConfig):

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -1,5 +1,8 @@
 from jira import JIRA, JIRAError, Issue
 from typing import List
+
+from flask import current_app as app
+
 from amundsen_application.base.base_issue_tracker_client import BaseIssueTrackerClient
 from amundsen_application.proxy.issue_tracker_clients.issue_exceptions import IssueConfigurationException
 from amundsen_application.models.data_issue import DataIssue
@@ -72,7 +75,8 @@ class JiraClient(BaseIssueTrackerClient):
             }, issuetype={
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
-            }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]'))
+            }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
+                reporter=app.config['AUTH_USER_METHOD'](app).email))
 
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -78,7 +78,7 @@ class JiraClient(BaseIssueTrackerClient):
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
             }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
-                reporter='ttannis'))
+                reporter={'name': 'ttannis'}))
 
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -72,6 +72,8 @@ class JiraClient(BaseIssueTrackerClient):
         try:
             if app.config['AUTH_USER_METHOD']:
                 user_email = app.config['AUTH_USER_METHOD'](app).email
+                # We currently cannot use the email directly because of the following issue:
+                # https://community.atlassian.com/t5/Answers-Developer-Questions/JIRA-Rest-API-find-JIRA-user-based-on-user-s-email-address/qaq-p/532715
                 jira_id = user_email.split('@')[0]
             else:
                 raise Exception('AUTH_USER_METHOD must be configured to set the JIRA issue reporter')
@@ -81,7 +83,10 @@ class JiraClient(BaseIssueTrackerClient):
             }, issuetype={
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
-            }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
+            }, summary=title,
+                description=(f'{description} '
+                             f'\n Reported By: {user_email} '
+                             f'\n Table Key: {table_uri} [PLEASE DO NOT REMOVE]'),
                 reporter={'name': jira_id}))
 
             return self._get_issue_properties(issue=issue)

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -70,8 +70,12 @@ class JiraClient(BaseIssueTrackerClient):
         :return: Metadata about the newly created issue
         """
         try:
-            user_email = app.config['AUTH_USER_METHOD'](app).email
-            jira_id = user_email.split('@')[0]
+            if app.config['AUTH_USER_METHOD']:
+                user_email = app.config['AUTH_USER_METHOD'](app).email
+                jira_id = user_email.split('@')[0]
+            else:
+                raise Exception('AUTH_USER_METHOD must be configured to set the JIRA issue reporter')
+
             issue = self.jira_client.create_issue(fields=dict(project={
                 'id': self.jira_project_id
             }, issuetype={

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -76,7 +76,7 @@ class JiraClient(BaseIssueTrackerClient):
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
             }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
-                reporter=app.config['AUTH_USER_METHOD'](app).email))
+                reporter={'email': app.config['AUTH_USER_METHOD'](app).email}))
 
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -70,13 +70,15 @@ class JiraClient(BaseIssueTrackerClient):
         :return: Metadata about the newly created issue
         """
         try:
+            # user_email = app.config['AUTH_USER_METHOD'](app).email
+            # Testing if we need user_id vs email
             issue = self.jira_client.create_issue(fields=dict(project={
                 'id': self.jira_project_id
             }, issuetype={
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
             }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
-                reporter={'email': app.config['AUTH_USER_METHOD'](app).email}))
+                reporter='ttannis'))
 
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/amundsen_application/proxy/issue_tracker_clients/jira_client.py
+++ b/amundsen_application/proxy/issue_tracker_clients/jira_client.py
@@ -70,15 +70,15 @@ class JiraClient(BaseIssueTrackerClient):
         :return: Metadata about the newly created issue
         """
         try:
-            # user_email = app.config['AUTH_USER_METHOD'](app).email
-            # Testing if we need user_id vs email
+            user_email = app.config['AUTH_USER_METHOD'](app).email
+            jira_id = user_email.split('@')[0]
             issue = self.jira_client.create_issue(fields=dict(project={
                 'id': self.jira_project_id
             }, issuetype={
                 'id': ISSUE_TYPE_ID,
                 'name': ISSUE_TYPE_NAME,
             }, summary=title, description=f'{description} \n Table Key: {table_uri} [PLEASE DO NOT REMOVE]',
-                reporter={'name': 'ttannis'}))
+                reporter={'name': jira_id}))
 
             return self._get_issue_properties(issue=issue)
         except JIRAError as e:

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -157,5 +157,7 @@ class JiraClientTest(unittest.TestCase):
             }, issuetype={
                 'id': 1,
                 'name': 'Bug',
-            }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
+            }, summary='title',
+                description='desc' + ' \n Reported By: test@email.com' +
+                            ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
                 reporter={'name': 'test'}))

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -157,4 +157,5 @@ class JiraClientTest(unittest.TestCase):
             }, issuetype={
                 'id': 1,
                 'name': 'Bug',
-            }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]'))
+            }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
+                reporter='test@email.com'))

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -158,4 +158,4 @@ class JiraClientTest(unittest.TestCase):
                 'id': 1,
                 'name': 'Bug',
             }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
-                reporter={'email': 'test@email.com'}))
+                reporter='ttannis'))

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -158,4 +158,4 @@ class JiraClientTest(unittest.TestCase):
                 'id': 1,
                 'name': 'Bug',
             }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
-                reporter='test@email.com'))
+                reporter={'email': 'test@email.com'}))

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -158,4 +158,4 @@ class JiraClientTest(unittest.TestCase):
                 'id': 1,
                 'name': 'Bug',
             }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
-                reporter={'name': 'ttannis'}))
+                reporter={'name': 'test'}))

--- a/tests/unit/issue_tracker_clients/test_jira_client.py
+++ b/tests/unit/issue_tracker_clients/test_jira_client.py
@@ -158,4 +158,4 @@ class JiraClientTest(unittest.TestCase):
                 'id': 1,
                 'name': 'Bug',
             }, summary='title', description='desc' + ' \n Table Key: ' + 'key [PLEASE DO NOT REMOVE]',
-                reporter='ttannis'))
+                reporter={'name': 'ttannis'}))


### PR DESCRIPTION
### Summary of Changes

Passing `reporter={'name': valid_jira_id}` sets the reporter for the issue. This current workaround can and should probably be improved in the future. It will not work for users who have aliases or any case where the `jira_id` is not the employee's email handle. 

### Tests

Updated relevant test.

### Documentation

N/A for now. If we keep this implementation we should call out the limitation above in the feature documentation.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
