### PR TITLE
Update logic to transform filters then call _search_table

### DIFF
--- a/amundsen_application/api/search/v0.py
+++ b/amundsen_application/api/search/v0.py
@@ -11,7 +11,7 @@ from flask.blueprints import Blueprint
 
 from amundsen_application.log.action_log import action_logging
 from amundsen_application.api.utils.request_utils import get_query_param, request_search
-from amundsen_application.api.utils.search_utils import generate_query_json, has_filters, map_table_result
+from amundsen_application.api.utils.search_utils import generate_query_json, has_filters, map_table_result, transform_filters
 from amundsen_application.models.user import load_user, dump_user
 
 LOGGER = logging.getLogger(__name__)
@@ -39,9 +39,9 @@ def search_table() -> Response:
 
         search_type = request_json.get('searchType')
 
-        filters = request_json.get('filters', {})
+        transformed_filters = transform_filters(filters=request_json.get('filters', {}))
 
-        results_dict = _search_table(filters=filters,
+        results_dict = _search_table(filters=transformed_filters,
                                      search_term=search_term,
                                      page_index=page_index,
                                      search_type=search_type)
@@ -76,14 +76,7 @@ def _search_table(*, search_term: str, page_index: int, filters: Dict, search_ty
 
     try:
         if has_filters(filters=filters):
-            try:
-                query_json = generate_query_json(filters=filters, page_index=page_index, search_term=search_term)
-            except Exception as e:
-                message = 'Encountered exception generating query json: ' + str(e)
-                results_dict['msg'] = message
-                logging.exception(message)
-                return results_dict
-
+            query_json = generate_query_json(filters=filters, page_index=page_index, search_term=search_term)
             url_base = app.config['SEARCHSERVICE_BASE'] + SEARCH_TABLE_FILTER_ENDPOINT
             response = request_search(url=url_base,
                                       headers={'Content-Type': 'application/json'},

--- a/amundsen_application/api/search/v0.py
+++ b/amundsen_application/api/search/v0.py
@@ -11,7 +11,8 @@ from flask.blueprints import Blueprint
 
 from amundsen_application.log.action_log import action_logging
 from amundsen_application.api.utils.request_utils import get_query_param, request_search
-from amundsen_application.api.utils.search_utils import generate_query_json, has_filters, map_table_result, transform_filters
+from amundsen_application.api.utils.search_utils import generate_query_json, has_filters, \
+    map_table_result, transform_filters
 from amundsen_application.models.user import load_user, dump_user
 
 LOGGER = logging.getLogger(__name__)

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -22,14 +22,12 @@ def map_table_result(result: Dict) -> Dict:
         'last_updated_timestamp': result.get('last_updated_timestamp', None),
     }
 
-
-def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str) -> Dict:
+def transform_filters(*, filters: Dict = {}) -> Dict:
     """
-    Transforms the given paramaters to the query json for the search service according to
-    the api defined at:
+    Transforms the data shape of filters from the application to the data
+    shape required by the search service according to the api defined at:
     https://github.com/lyft/amundsensearchlibrary/blob/master/search_service/api/swagger_doc/table/search_table_filter.yml
     """
-    # Generate the filter payload
     filter_payload = {}
     for category in valid_search_fields:
         values = filters.get(category)
@@ -42,19 +40,32 @@ def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str
         if len(value_list) > 0:
             filter_payload[category] = value_list
 
-    # Return the full query json
+    return filter_payload
+
+
+def generate_query_json(*, filters: Dict = {}, page_index: int, search_term: str) -> Dict:
+    """
+    Transforms the given paramaters to the query json for the search service according to
+    the api defined at:
+    https://github.com/lyft/amundsensearchlibrary/blob/master/search_service/api/swagger_doc/table/search_table_filter.yml
+    """
     return {
         'page_index': int(page_index),
         'search_request': {
             'type': 'AND',
-            'filters': filter_payload
+            'filters': filters
         },
         'query_term': search_term
     }
 
 
 def has_filters(*, filters: Dict = {}) -> bool:
+    """
+    Returns whether or not the filter dictionary passed to the search service
+    has at least one filter value for a valid filter category
+    """
     for category in valid_search_fields:
-        if filters.get(category) is not None:
+        filter_list = filters.get(category, [])
+        if len(filter_list) > 0:
             return True
     return False

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -22,6 +22,7 @@ def map_table_result(result: Dict) -> Dict:
         'last_updated_timestamp': result.get('last_updated_timestamp', None),
     }
 
+
 def transform_filters(*, filters: Dict = {}) -> Dict:
     """
     Transforms the data shape of filters from the application to the data

--- a/tests/unit/utils/test_search_utils.py
+++ b/tests/unit/utils/test_search_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from amundsen_application.api.utils.search_utils import generate_query_json, has_filters
+from amundsen_application.api.utils.search_utils import generate_query_json, has_filters, transform_filters
 
 
 class SearchUtilsTest(unittest.TestCase):
@@ -27,12 +27,19 @@ class SearchUtilsTest(unittest.TestCase):
         self.test_page_index = "1"
         self.test_term = 'hello'
 
+    def test_transform_filters(self) -> None:
+        """
+        Verify that the given filters are correctly transformed
+        :return:
+        """
+        self.assertEqual(transform_filters(filters=self.test_filters), self.expected_transformed_filters)
+
     def test_generate_query_json(self) -> None:
         """
         Verify that the returned diction correctly transforms the parameters
         :return:
         """
-        query_json = generate_query_json(filters=self.test_filters,
+        query_json = generate_query_json(filters=self.expected_transformed_filters,
                                          page_index=self.test_page_index,
                                          search_term=self.test_term)
         self.assertEqual(query_json.get('page_index'), int(self.test_page_index))
@@ -47,13 +54,13 @@ class SearchUtilsTest(unittest.TestCase):
         Returns true if called with a dictionary that has values for a valid filter category
         :return:
         """
-        self.assertTrue(has_filters(filters=self.test_filters))
+        self.assertTrue(has_filters(filters=self.expected_transformed_filters))
 
     def test_has_filters_return_false(self) -> None:
         """
         Returns false if called with a dictionary that has no values for a valid filter category
         :return:
         """
-        test_filters = {'fake_category': {'db1': True}}
-        self.assertFalse(has_filters(filters=test_filters))
+        self.assertFalse(has_filters(filters={'fake_category': ['db1']}))
+        self.assertFalse(has_filters(filters={'tag': []}))
         self.assertFalse(has_filters())


### PR DESCRIPTION
### Summary of Changes

This PR updates our search logic to transform the frontend filter shape --> search service filter shape before calling `_search_table`, so that our logs will capture the exactly what gets passed to the search service. Motivations for doing this are:
1. The data shape from the frontend application state is not documented anywhere and should be treated as a black box. It is more subject to change based on application needs and new features.
2. The data shape for filters on the search service api  is more concise

### Tests

Updated tests according to changes.

### Documentation

N/A for this kind of change.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
