### PR TITLE
Cast input to lowercase like we do for SearchBar

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/InputFilter/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/InputFilter/index.tsx
@@ -54,7 +54,7 @@ export class InputFilter extends React.Component<InputFilterProps, InputFilterSt
   };
 
   onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ value: e.target.value })
+    this.setState({ value: e.target.value.toLowerCase() })
   };
 
   render = () => {

--- a/amundsen_application/static/js/components/SearchPage/SearchFilter/InputFilter/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchFilter/InputFilter/tests/index.spec.tsx
@@ -115,9 +115,10 @@ describe('InputFilter', () => {
     it('sets the value state to e.target.value', () => {
       setStateSpy.mockClear()
       const mockValue = 'mockValue';
+      const expectedValue = 'mockvalue'
       const mockEvent = { target: { value: mockValue }};
       wrapper.instance().onInputChange(mockEvent)
-      expect(setStateSpy).toHaveBeenCalledWith({ value: mockValue });
+      expect(setStateSpy).toHaveBeenCalledWith({ value: expectedValue });
     });
   });
 


### PR DESCRIPTION
### Summary of Changes

Because search is currently case sensitive, the filter will not return results if someone enters uppercase. To address this `InputFilter` will do the same thing `SearchBar` has been doing, and cast the value to lower case automatically on input.

As a note, the ideal experience for this would be addressed by: https://github.com/lyft/amundsen/issues/283

### Tests

Updated applicable test

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
