### PR TITLE
Clean up some tests for programmatic descriptions feature

### DIFF
--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -115,12 +115,6 @@ class TestConfig(LocalConfig):
     ISSUE_TRACKER_CLIENT_ENABLED = True
     ISSUE_TRACKER_MAX_RESULTS = 3
 
-    PROGRAMMATIC_DISPLAY = {
-        "a_1": {
-            "display_order": 0
-        }
-    }
-
 
 class TestNotificationsDisabledConfig(LocalConfig):
     AUTH_USER_METHOD = get_test_user

--- a/amundsen_application/static/js/components/TableDetail/EditableSection/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/EditableSection/tests/index.spec.tsx
@@ -46,11 +46,15 @@ describe("EditableSection", () => {
   });
 
   describe("render", () => {
-    const customTitle = "custom title";
-    const { wrapper, props } = setup({ title: customTitle }, <TagInput/>);
+    const mockTitle = 'Mock';
+    const convertTextSpy = jest.spyOn(EditableSection, 'convertText').mockImplementation(() => mockTitle);
+    const { wrapper, props } = setup({ title: 'custom title' }, <TagInput/>);
 
-    it("sets the title from a prop", () => {
-      expect(wrapper.find(".section-title").text()).toBe("Custom Title");
+    it("renders the converted props.title as the section title", () => {
+      convertTextSpy.mockClear();
+      wrapper.instance().render();
+      expect(convertTextSpy).toHaveBeenCalledWith(props.title);
+      expect(wrapper.find(".section-title").text()).toBe(mockTitle);
     });
 
     it("renders children with additional props", () => {
@@ -75,9 +79,5 @@ describe("EditableSection", () => {
       const { wrapper } = setup({readOnly: true}, <TagInput/>);
       expect(wrapper.find(".edit-button").length).toEqual(0);
     });
-
-    it('renders modifies title to have no underscores', () => {
-      expect(EditableSection.convertText("testing_a123_b456 c789")).toEqual("Testing A123 B456 C789")
-    })
   });
 });

--- a/amundsen_application/static/js/components/TableDetail/constants.ts
+++ b/amundsen_application/static/js/components/TableDetail/constants.ts
@@ -1,0 +1,1 @@
+export const PROGRMMATIC_DESC_HEADER = 'Read-only information, auto-generated'

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -15,6 +15,7 @@ import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 import Breadcrumb from 'components/common/Breadcrumb';
 import DataPreviewButton from 'components/TableDetail/DataPreviewButton';
 import ColumnList from 'components/TableDetail/ColumnList';
+import EditableText from 'components/common/EditableText';
 import ExploreButton from 'components/TableDetail/ExploreButton';
 import Flag from 'components/common/Flag';
 import FrequentUsers from 'components/TableDetail/FrequentUsers';
@@ -40,7 +41,8 @@ import { formatDateTimeShort } from 'utils/dateUtils';
 import './styles';
 import RequestDescriptionText from './RequestDescriptionText';
 import RequestMetadataForm from './RequestMetadataForm';
-import EditableText from "components/common/EditableText";
+
+import { PROGRMMATIC_DESC_HEADER } from './constants';
 
 export interface StateFromProps {
   isLoading: boolean;
@@ -211,9 +213,10 @@ class TableDetail extends React.Component<TableDetailProps & RouteComponentProps
                   </EditableSection>
                 </section>
               </section>
-              {data.programmatic_descriptions.length > 0 &&
+              {
+                data.programmatic_descriptions.length > 0 &&
                 <>
-                  <div className="programmatic-title title-4">Read-Only information, Auto-Generated.</div>
+                  <div className="programmatic-title title-4">{PROGRMMATIC_DESC_HEADER}</div>
                   <hr className="programmatic-hr hr1"/>
                 </>
               }

--- a/tests/unit/utils/test_metadata_utils.py
+++ b/tests/unit/utils/test_metadata_utils.py
@@ -1,115 +1,65 @@
 import unittest
 
-from amundsen_application.api.utils.metadata_utils import marshall_table_full
+from unittest.mock import patch, Mock
+
+from amundsen_application.api.utils.metadata_utils import _update_prog_descriptions, _sort_prog_descriptions
 from amundsen_application import create_app
 
 local_app = create_app('amundsen_application.config.TestConfig', 'tests/templates')
 
 
-class MetadataUtilsTest(unittest.TestCase):
+class ProgrammaticDescriptionsTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.input_data = {
-            'cluster': 'test_cluster',
-            'columns': [
-                {
-                    'name': 'column_1',
-                    'description': 'This is a test',
-                    'col_type': 'bigint',
-                    'sort_order': 0,
-                    'stats': [
-                        {'stat_type': 'count', 'stat_val': '100', 'start_epoch': 1538352000, 'end_epoch': 1538352000},
-                        {'stat_type': 'count_null', 'stat_val': '0', 'start_epoch': 1538352000, 'end_epoch': 1538352000}
-                    ]
-                }
-            ],
-            'database': 'test_db',
-            'is_view': False,
-            'key': 'test_db://test_cluster.test_schema/test_table',
-            'owners': [],
-            'schema': 'test_schema',
-            'name': 'test_table',
-            'table_description': 'This is a test',
-            'tags': [],
-            'table_readers': [
-                {'user': {'email': 'test@test.com', 'first_name': None, 'last_name': None}, 'read_count': 100}
-            ],
-            'watermarks': [
-                {'watermark_type': 'low_watermark', 'partition_key': 'ds', 'partition_value': '', 'create_time': ''},
-                {'watermark_type': 'high_watermark', 'partition_key': 'ds', 'partition_value': '', 'create_time': ''}
-            ],
-            'table_writer': {
-                'application_url': 'https://test-test.test.test',
-                'name': 'test_name',
-                'id': 'test_id',
-                'description': 'This is a test'
-            },
-            'programmatic_descriptions': [
+        pass
+
+    @patch('amundsen_application.api.utils.metadata_utils._sort_prog_descriptions')
+    def test_update_prog_descriptions(self, sort_mock) -> None:
+        with local_app.app_context():
+            test_desc = [
                 {'source': 'c_1', 'text': 'description c'},
                 {'source': 'a_1', 'text': 'description a'},
                 {'source': 'b_1', 'text': 'description b'}
             ]
-        }
+            # Pretend config exists
+            local_app.config['PROGRAMMATIC_DISPLAY'] = Mock()
+            # Mock the effects of the sort method
+            sort_mock.side_effect = [1, 0, 1]
+            # Expected order based on mocked side effect
+            expected_programmatic_desc = [
+                {'source': 'a_1', 'text': 'description a'},
+                {'source': 'c_1', 'text': 'description c'},
+                {'source': 'b_1', 'text': 'description b'}
+            ]
+            _update_prog_descriptions(test_desc)
+            self.assertEqual(test_desc, expected_programmatic_desc)
 
-        self.expected_data = {'badges': [],
-                              'cluster': 'test_cluster',
-                              'columns': [{'col_type': 'bigint',
-                                           'description': 'This is a test',
-                                           'name': 'column_1',
-                                           'sort_order': 0,
-                                           'stats': [{'end_epoch': 1538352000,
-                                                      'start_epoch': 1538352000,
-                                                      'stat_type': 'count',
-                                                      'stat_val': '100'},
-                                                     {'end_epoch': 1538352000,
-                                                      'start_epoch': 1538352000,
-                                                      'stat_type': 'count_null',
-                                                      'stat_val': '0'}]}],
-                              'database': 'test_db',
-                              'description': None,
-                              'is_editable': True,
-                              'is_view': False,
-                              'key': 'test_db://test_cluster.test_schema/test_table',
-                              'last_updated_timestamp': None,
-                              'name': 'test_table',
-                              'owners': [],
-                              'partition': {'is_partitioned': True, 'key': 'ds', 'value': ''},
-                              'programmatic_descriptions': [{'source': 'a_1', 'text': 'description a'},
-                                                            {'source': 'c_1', 'text': 'description c'},
-                                                            {'source': 'b_1', 'text': 'description b'}],
-                              'schema': 'test_schema',
-                              'source': None,
-                              'table_readers': [{'read_count': 100,
-                                                 'user': {'display_name': 'test@test.com',
-                                                          'email': 'test@test.com',
-                                                          'employee_type': None,
-                                                          'first_name': None,
-                                                          'full_name': None,
-                                                          'github_username': None,
-                                                          'is_active': True,
-                                                          'last_name': None,
-                                                          'manager_email': None,
-                                                          'manager_fullname': None,
-                                                          'profile_url': '',
-                                                          'role_name': None,
-                                                          'slack_id': None,
-                                                          'team_name': None,
-                                                          'user_id': 'test@test.com'}}],
-                              'table_writer': {'application_url': 'https://test-test.test.test',
-                                               'description': 'This is a test',
-                                               'id': 'test_id',
-                                               'kind': None,
-                                               'name': 'test_name'},
-                              'tags': [],
-                              'watermarks': [{'create_time': '',
-                                              'partition_key': 'ds',
-                                              'partition_value': '',
-                                              'watermark_type': 'low_watermark'},
-                                             {'create_time': '',
-                                              'partition_key': 'ds',
-                                              'partition_value': '',
-                                              'watermark_type': 'high_watermark'}]}
-
-    def test_marshal_table_full(self) -> None:
+    def test_sort_prog_descriptions_returns_value_from_config(self) -> None:
+        """
+        Verify the method will return the display order from the programmtic description
+        configuration if it exists for the given source
+        :return:
+        """
         with local_app.app_context():
-            actual_result = marshall_table_full(self.input_data)
-            self.assertEqual(actual_result, self.expected_data)
+            mock_order = 1
+            mock_config = {
+                "c_1": {
+                    "display_order": mock_order
+                }
+            }
+            in_config_value = {'source': 'c_1', 'text': 'I am a test'}
+            self.assertEqual(_sort_prog_descriptions(mock_config, in_config_value), mock_order)
+
+    def test_sort_prog_descriptions_returns_default_value(self) -> None:
+        """
+        Verify the method will return the expected default value if programmtic decsription
+        source is not included in teh configuration
+        :return:
+        """
+        with local_app.app_context():
+            mock_config = {
+                "c_1": {
+                    "display_order": 0
+                }
+            }
+            not_in_config_value = {'source': 'test', 'text': 'I am a test'}
+            self.assertEqual(_sort_prog_descriptions(mock_config, not_in_config_value), len(mock_config))


### PR DESCRIPTION
### Summary of Changes

Some cleanup on top of https://github.com/lyft/amundsenfrontendlibrary/pull/381
1. Python unit tests were updated to explicitly test the behavior of helper functions added in `metadata_utils`
2. Placed hardcoded text from `TableDetail` into a `constants` file. We are separating out hardcoded user-readable text for out components because it will make them easier to update in the future -- especially if we eventually allow for constants for be overwritten.
3. Updated the test for the `EditableSection` title to verify that convertText() is called and the result of that method is what gets rendered. 

### Tests

Included above.

### Documentation

N/A. Features have not been modified.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
