### PR TITLE
Do not render component if no lineage url

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/LineageLink/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/LineageLink/index.tsx
@@ -15,6 +15,8 @@ const LineageLink: React.SFC<LineageLinkProps> = ({ tableData }) => {
 
   const { database, cluster, schema, name } = tableData;
   const href = config.urlGenerator(database, cluster, schema, name);
+  if (!href) return null;
+  
   const label = 'Lineage';
 
   return (


### PR DESCRIPTION
### Summary of Changes

For tables with no lineage url or empty string we used to not show the compiler works link. There was an oversight on the new design logic to account for this. The effect is that lineage links are rendered and Chrome makes it link back to the same page when `href` is undefined.

### Tests

This are remains untested.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
