### PR TITLE
Prevent entering of ':' into search term

### DIFF
--- a/amundsen_application/static/js/components/common/SearchBar/constants.ts
+++ b/amundsen_application/static/js/components/common/SearchBar/constants.ts
@@ -4,3 +4,5 @@ export const PLACEHOLDER_DEFAULT = 'search for data resources...';
 export const BUTTON_CLOSE_TEXT = 'Close';
 
 export const SIZE_SMALL = 'small';
+
+export const INVALID_SYNTAX_MESSAGE = 'Your search termc contains invalid syntax';

--- a/amundsen_application/static/js/components/common/SearchBar/constants.ts
+++ b/amundsen_application/static/js/components/common/SearchBar/constants.ts
@@ -5,4 +5,4 @@ export const BUTTON_CLOSE_TEXT = 'Close';
 
 export const SIZE_SMALL = 'small';
 
-export const INVALID_SYNTAX_MESSAGE = 'Your search termc contains invalid syntax';
+export const INVALID_SYNTAX_MESSAGE = "Your search term contains invalid syntax ':'.";

--- a/amundsen_application/static/js/components/common/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/index.tsx
@@ -92,12 +92,14 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
   handleValueChange = (event: React.SyntheticEvent<HTMLInputElement>) : void => {
     const searchTerm = (event.target as HTMLInputElement).value.toLowerCase();
 
-    if (searchTerm.length > 0) {
-      this.props.onInputChange(searchTerm);
-      this.setState({ searchTerm, showTypeAhead: true });
-    }
-    else {
-      this.clearSearchTerm();
+    if (searchTerm.indexOf(':') < 0) {
+      if (searchTerm.length > 0) {
+        this.props.onInputChange(searchTerm);
+        this.setState({ searchTerm, showTypeAhead: true });
+      }
+      else {
+        this.clearSearchTerm();
+      }
     }
   };
 

--- a/amundsen_application/static/js/components/common/SearchBar/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/index.tsx
@@ -16,6 +16,7 @@ import './styles.scss';
 
 import {
   BUTTON_CLOSE_TEXT,
+  INVALID_SYNTAX_MESSAGE,
   PLACEHOLDER_DEFAULT,
   SIZE_SMALL
 } from './constants';
@@ -92,7 +93,7 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
   handleValueChange = (event: React.SyntheticEvent<HTMLInputElement>) : void => {
     const searchTerm = (event.target as HTMLInputElement).value.toLowerCase();
 
-    if (searchTerm.indexOf(':') < 0) {
+    if (this.isFormValid(searchTerm)) {
       if (searchTerm.length > 0) {
         this.props.onInputChange(searchTerm);
         this.setState({ searchTerm, showTypeAhead: true });
@@ -100,13 +101,15 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
       else {
         this.clearSearchTerm();
       }
+    } else {
+      this.setState({ searchTerm, showTypeAhead: false });
     }
   };
 
   handleValueSubmit = (event: React.FormEvent<HTMLFormElement>) : void => {
     const searchTerm = this.state.searchTerm.trim();
     event.preventDefault();
-    if (this.isFormValid()) {
+    if (this.isFormValid(searchTerm)) {
       this.props.submitSearch(searchTerm);
       this.hideTypeAhead();
     }
@@ -116,9 +119,20 @@ export class SearchBar extends React.Component<SearchBarProps, SearchBarState> {
     this.setState({ showTypeAhead: false });
   };
 
-  isFormValid = () : boolean => {
+  isFormValid = (searchTerm: string) : boolean => {
     const form = document.getElementById("search-bar-form") as HTMLFormElement;
-    return form.checkValidity();
+    const input = document.getElementById("search-input") as HTMLInputElement;
+    const isValid = searchTerm.indexOf(':') < 0;
+
+    /* This will set the error message, it must be explicitly set or cleared each time */
+    input.setCustomValidity(isValid ? "": INVALID_SYNTAX_MESSAGE)
+
+    if (searchTerm.length > 0) {
+      /* This will show the error message */
+      form.reportValidity();
+    }
+
+    return isValid;
   };
 
   onSelectInlineResult = (resourceType: ResourceType, updateUrl: boolean = false) : void => {

--- a/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
@@ -90,50 +90,61 @@ describe('SearchBar', () => {
   describe('handleValueChange', () => {
     let props;
     let wrapper;
+    let isFormValidSpy;
     beforeAll(() => {
       const setupResult = setup();
       props = setupResult.props;
       wrapper = setupResult.wrapper;
-      jest.spyOn(wrapper.instance(), 'isFormValid').mockImplementation(() => true);
+      isFormValidSpy = jest.spyOn(wrapper.instance(), 'isFormValid');
     });
 
-    /* TBD: Update test based on the approach we choose
-    it('does nothing if user enters a colon', () => {
-      setStateSpy.mockClear();
-      props.onInputChange.mockClear();
-      // @ts-ignore: mocked events throw type errors
-      wrapper.instance().handleValueChange({ target: { value: 'dont:dothis' } });
-      expect(setStateSpy).not.toHaveBeenCalled();
-      expect(props.onInputChange).not.toHaveBeenCalled();
-    }); */
+    describe('when form is not valid', () => {
+      beforeAll(() => {
+        isFormValidSpy.mockImplementation(() => false)
+      })
 
-    describe('if searchTerm has length', () => {
-      const mockSearchTerm = 'I have Length';
-      const expectedSearchTerm = 'i have length';
-      it('calls setState with searchTerm as lowercase target value & showTypeAhead as true ', () => {
+      it('updates the searchTerm (for visual feedback) and hides type ahead', () => {
         setStateSpy.mockClear();
+        const testTerm = 'hello';
         // @ts-ignore: mocked events throw type errors
-        wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
-        expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: expectedSearchTerm, showTypeAhead: true });
-      });
-
-      it('calls onInputChange with searchTerm as lowercase target value', () => {
-        // @ts-ignore: mocked events throw type errors
-        props.onInputChange.mockClear();
-        wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
-        expect(props.onInputChange).toHaveBeenCalledWith(expectedSearchTerm);
-      });
+        wrapper.instance().handleValueChange({ target: { value: testTerm } });
+        expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: testTerm, showTypeAhead: false });
+      })
     })
 
-    describe('if searchTerm has zero length', () => {
-      const mockSearchTerm = '';
-      it('calls clearSearchTerm', () => {
-        const clearSearchTermSpy = jest.spyOn(wrapper.instance(), 'clearSearchTerm');
-        // @ts-ignore: mocked events throw type errors
-        wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
-        expect(clearSearchTermSpy).toHaveBeenCalled();
+    describe('when form is valid', () => {
+      beforeAll(() => {
+        isFormValidSpy.mockImplementation(() => true)
+      })
+
+      describe('if searchTerm has length', () => {
+        const mockSearchTerm = 'I have Length';
+        const expectedSearchTerm = 'i have length';
+        it('calls setState with searchTerm as lowercase target value & showTypeAhead as true ', () => {
+          setStateSpy.mockClear();
+          // @ts-ignore: mocked events throw type errors
+          wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
+          expect(setStateSpy).toHaveBeenCalledWith({ searchTerm: expectedSearchTerm, showTypeAhead: true });
+        });
+
+        it('calls onInputChange with searchTerm as lowercase target value', () => {
+          // @ts-ignore: mocked events throw type errors
+          props.onInputChange.mockClear();
+          wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
+          expect(props.onInputChange).toHaveBeenCalledWith(expectedSearchTerm);
+        });
+      })
+
+      describe('if searchTerm has zero length', () => {
+        const mockSearchTerm = '';
+        it('calls clearSearchTerm', () => {
+          const clearSearchTermSpy = jest.spyOn(wrapper.instance(), 'clearSearchTerm');
+          // @ts-ignore: mocked events throw type errors
+          wrapper.instance().handleValueChange({ target: { value: mockSearchTerm } });
+          expect(clearSearchTermSpy).toHaveBeenCalled();
+        });
       });
-    });
+    })
   });
 
   describe('handleValueSubmit', () => {

--- a/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
@@ -94,8 +94,10 @@ describe('SearchBar', () => {
       const setupResult = setup();
       props = setupResult.props;
       wrapper = setupResult.wrapper;
+      jest.spyOn(wrapper.instance(), 'isFormValid').mockImplementation(() => true);
     });
 
+    /* TBD: Update test based on the approach we choose
     it('does nothing if user enters a colon', () => {
       setStateSpy.mockClear();
       props.onInputChange.mockClear();
@@ -103,7 +105,7 @@ describe('SearchBar', () => {
       wrapper.instance().handleValueChange({ target: { value: 'dont:dothis' } });
       expect(setStateSpy).not.toHaveBeenCalled();
       expect(props.onInputChange).not.toHaveBeenCalled();
-    });
+    }); */
 
     describe('if searchTerm has length', () => {
       const mockSearchTerm = 'I have Length';

--- a/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/tests/index.spec.tsx
@@ -96,6 +96,15 @@ describe('SearchBar', () => {
       wrapper = setupResult.wrapper;
     });
 
+    it('does nothing if user enters a colon', () => {
+      setStateSpy.mockClear();
+      props.onInputChange.mockClear();
+      // @ts-ignore: mocked events throw type errors
+      wrapper.instance().handleValueChange({ target: { value: 'dont:dothis' } });
+      expect(setStateSpy).not.toHaveBeenCalled();
+      expect(props.onInputChange).not.toHaveBeenCalled();
+    });
+
     describe('if searchTerm has length', () => {
       const mockSearchTerm = 'I have Length';
       const expectedSearchTerm = 'i have length';


### PR DESCRIPTION
### Summary of Changes

#### Context
1. Some users still entered advanced search syntax into the search bar.
2. If a colon is in the search term, it will break the filter endpoint.
3. A fix was made in amundsensearchlibrary to return HTTPStatus.BAD_REQUEST in this case

This PR aimed to create a better experience for this on the frontend, by surfacing information about non-successful requests. 

#### Initial Goal
The initial plan to was show different messages on the `SearchPage` for 5xx and 4xx errors. However the work effort turned out to be too great given current priorities. Our search bar searches batches the 3 requests to each resource endpoint and we would have to restructure this to be able to capture error codes only for the resources that fail  and store it on the search state for that resource.

#### Current Solution
Because of the scope creep my current solution pulls things back to just prevent entering a ':' in the search bar. 

If we ever re-introduce advanced search syntax this workaround can be deleted, and I think we can still invest effort into showing better error messages on the `SearchPage` for each resource request when bandwidth allows. 

### Tests

Added test for use case

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
