### PR TITLE
Add Dashboard Preview UI Support

### DIFF
--- a/amundsen_application/api/preview/dashboard/v0.py
+++ b/amundsen_application/api/preview/dashboard/v0.py
@@ -45,6 +45,7 @@ def get_preview_image(uri: str) -> Response:
                          mimetype='image/jpeg',
                          cache_timeout=app.config['DASHBOARD_PREVIEW_IMAGE_CACHE_MAX_AGE_SECONDS'])
     except FileNotFoundError as fne:
+        LOGGER.exception('FileNotFoundError on get_preview_image')
         return make_response(jsonify({'msg': fne.args[0]}), HTTPStatus.NOT_FOUND)
     except Exception as e:
         LOGGER.exception('Unexpected failure on get_preview_image')

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/constants.ts
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ERROR_MESSAGE = 'An error ocurred loading the image preview, please refresh the page';

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.spec.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.spec.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { ImagePreview, ImagePreviewProps, mapStateToProps, mapDispatchToProps } from './';
+
+import LoadingSpinner from 'components/common/LoadingSpinner';
+
+import globalState from 'fixtures/globalState';
+import { errorPreviewStateNoMessage, errorPreviewStateWithMessage } from 'fixtures/dashboard/preview';
+
+import * as Constants from './constants';
+
+describe('ImagePreview', () => {
+  const setup = (propOverrides?: Partial<ImagePreviewProps>) => {
+    const props = {
+      uri: 'test:uri/value',
+      url: 'someUrl',
+      errorMessage: 'oops',
+      errorCode: undefined,
+      isLoading: false,
+      getPreviewImage: jest.fn(),
+      ...propOverrides,
+    };
+
+    const wrapper = shallow<ImagePreview>(<ImagePreview {...props} />)
+    return { props, wrapper };
+  };
+
+  describe('componentDidMount', () => {
+    it('triggers logic for preview image to load', () => {
+      const { props, wrapper } = setup();
+      expect(props.getPreviewImage).toHaveBeenCalledWith({ uri: props.uri });
+    })
+  })
+
+  describe('render', () => {
+    let props;
+    let wrapper;
+    let element;
+    beforeAll(() => {
+      const setupResult = setup();
+      props = setupResult.props;
+      wrapper = setupResult.wrapper;
+      element = wrapper.find('.image-preview');
+    })
+
+    it('renders the loading spinner when loading', () => {
+      const { props, wrapper } = setup({ isLoading: true })
+      expect(wrapper.find(LoadingSpinner).exists()).toBeTruthy();
+    });
+
+    it('renders the error message if and error code exists', () => {
+      const { props, wrapper } = setup({ errorCode: 500 })
+      expect(wrapper.find('.loading-error-text').text()).toBe(props.errorMessage);
+    });
+
+    it('renders an image with expected source if no error', () => {
+      expect(element.find('img').props().src).toBe(props.url);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    let result;
+    let testState;
+    beforeAll(() => {
+      testState = {
+        ...globalState,
+      }
+      result = mapStateToProps(testState);
+    });
+
+    it('sets url on the props', () => {
+      expect(result.url).toEqual(testState.dashboard.preview.url);
+    });
+
+    describe('sets error properties on the props', () => {
+      beforeAll(() => {
+        testState = {
+          ...globalState,
+          dashboard: {
+            ...globalState.dashboard,
+            preview: errorPreviewStateWithMessage,
+          }
+        }
+        result = mapStateToProps(testState);
+      });
+
+      it('sets errorMessage if it exists', () => {
+        expect(result.errorMessage).toEqual(testState.dashboard.preview.errorMessage);
+      });
+
+      it('sets errorCode on the props', () => {
+        expect(result.errorCode).toEqual(testState.dashboard.preview.errorCode);
+      });
+
+      it('uses default message errorMessage does not exist on the state', () => {
+        testState = {
+          ...globalState,
+          dashboard: {
+            ...globalState.dashboard,
+            preview: errorPreviewStateNoMessage,
+          }
+        }
+        result = mapStateToProps(testState);
+        expect(result.errorMessage).toEqual(Constants.DEFAULT_ERROR_MESSAGE);
+      });
+    });
+
+    it('sets isLoading on the props', () => {
+      expect(result.isLoading).toEqual(testState.dashboard.preview.isLoading);
+    });
+  });
+
+
+  describe('mapDispatchToProps', () => {
+    let dispatch;
+    let result;
+    beforeAll(() => {
+      dispatch = jest.fn(() => Promise.resolve());
+      result = mapDispatchToProps(dispatch);
+    });
+
+    it('sets getPreviewImage on the props', () => {
+      expect(result.getPreviewImage).toBeInstanceOf(Function);
+    });
+  });
+});

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import { getDashboardPreview } from 'ducks/dashboard/reducer';
+import { GlobalState } from 'ducks/rootReducer';
+
+import LoadingSpinner from 'components/common/LoadingSpinner';
+
+import './styles.scss';
+
+export interface OwnProps {
+  uri: string;
+}
+
+export interface StateFromProps {
+  url: string;
+  errorMessage: string;
+  errorCode: number | undefined;
+  isLoading: boolean;
+}
+
+export interface DispatchFromProps {
+  getPreviewImage: (payload: { uri: string }) => any; // TODO ttannis: Update this
+}
+
+export type ImagePreviewProps = StateFromProps & DispatchFromProps & OwnProps;
+
+export class ImagePreview extends React.Component<ImagePreviewProps, {}> {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount = () =>  {
+    this.props.getPreviewImage({ uri: this.props.uri });
+  }
+
+  render = () =>  {
+    const { errorCode, errorMessage, isLoading, url } = this.props;
+    let content;
+    if (isLoading) {
+      content = <LoadingSpinner/>;
+    }
+    else if (errorCode) {
+      content =  <div className="loading-error-text body-placeholder">{ errorMessage }</div>;
+    }
+    else {
+      content = <img src={this.props.url} height="auto" width="100%" />;
+    }
+
+    return (
+      <div className='image-preview'>
+        { content }
+      </div>
+    );
+  }
+}
+
+export const mapStateToProps = (state: GlobalState) => {
+  return {
+    url: state.dashboard.preview.url,
+    errorMessage: state.dashboard.preview.errorMessage || '',
+    errorCode: state.dashboard.preview.errorCode || undefined,
+    isLoading: state.dashboard.preview.isLoading,
+  };
+};
+
+export const mapDispatchToProps = (dispatch: any) => {
+  return bindActionCreators({
+    getPreviewImage: getDashboardPreview,
+  } , dispatch);
+};
+
+export default connect<StateFromProps, DispatchFromProps, OwnProps>(mapStateToProps, mapDispatchToProps)(ImagePreview);

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -7,6 +7,7 @@ import { GlobalState } from 'ducks/rootReducer';
 
 import LoadingSpinner from 'components/common/LoadingSpinner';
 
+import * as Constants from './constants';
 import './styles.scss';
 
 export interface OwnProps {
@@ -59,7 +60,7 @@ export class ImagePreview extends React.Component<ImagePreviewProps, {}> {
 export const mapStateToProps = (state: GlobalState) => {
   return {
     url: state.dashboard.preview.url,
-    errorMessage: state.dashboard.preview.errorMessage || '',
+    errorMessage: state.dashboard.preview.errorMessage || Constants.DEFAULT_ERROR_MESSAGE,
     errorCode: state.dashboard.preview.errorCode || undefined,
     isLoading: state.dashboard.preview.isLoading,
   };

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import { getDashboardPreview } from 'ducks/dashboard/reducer';
+import { GetDashboardPreviewRequest } from 'ducks/dashboard/types';
 import { GlobalState } from 'ducks/rootReducer';
 
 import LoadingSpinner from 'components/common/LoadingSpinner';
@@ -22,7 +23,7 @@ export interface StateFromProps {
 }
 
 export interface DispatchFromProps {
-  getPreviewImage: (payload: { uri: string }) => any; // TODO ttannis: Update this
+  getPreviewImage: (payload: { uri: string }) => GetDashboardPreviewRequest
 }
 
 export type ImagePreviewProps = StateFromProps & DispatchFromProps & OwnProps;

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -61,7 +61,7 @@ export const mapStateToProps = (state: GlobalState) => {
   return {
     url: state.dashboard.preview.url,
     errorMessage: state.dashboard.preview.errorMessage || Constants.DEFAULT_ERROR_MESSAGE,
-    errorCode: state.dashboard.preview.errorCode || undefined,
+    errorCode: state.dashboard.preview.errorCode,
     isLoading: state.dashboard.preview.isLoading,
   };
 };

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/styles.scss
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/styles.scss
@@ -1,0 +1,9 @@
+.image-preview {
+  .loading-spinner {
+    margin-top: 0;
+  }
+
+  .loading-error-text {
+    text-align: center;
+  }
+}

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -16,8 +16,11 @@ import { GetDashboardRequest } from 'ducks/dashboard/types';
 import { GlobalState } from 'ducks/rootReducer';
 import { logClick } from 'ducks/utilMethods';
 import { Dashboard } from 'interfaces/Dashboard';
+import ImagePreview from './ImagePreview';
 import QueryList from 'components/DashboardPage/QueryList';
 import ChartList from 'components/DashboardPage/ChartList';
+
+import './styles.scss';
 
 export interface RouteProps {
   uri: string;
@@ -136,6 +139,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, Dashboard
                   </div>
                 </section>
             </section>
+            <ImagePreview uri={this.state.uri} />
           </section>
           <section className="right-panel">
             { this.renderTabs() }

--- a/amundsen_application/static/js/components/DashboardPage/styles.scss
+++ b/amundsen_application/static/js/components/DashboardPage/styles.scss
@@ -1,0 +1,8 @@
+@import 'variables';
+
+.dashboard-page {
+  .image-preview {
+    margin-top: $spacer-3;
+    min-height: -webkit-fill-available;
+  }
+}

--- a/amundsen_application/static/js/components/DashboardPage/styles.scss
+++ b/amundsen_application/static/js/components/DashboardPage/styles.scss
@@ -4,5 +4,9 @@
   .image-preview {
     margin-top: $spacer-3;
     min-height: -webkit-fill-available;
+
+    img {
+      margin-bottom: $spacer-3;
+    }
   }
 }

--- a/amundsen_application/static/js/components/DashboardPage/test.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/test.tsx
@@ -45,7 +45,7 @@ describe('DashboardPage', () => {
         query_names: [],
         tables: [],
         tags: [],
-        },
+      },
       getDashboard: jest.fn(),
       ...routerProps,
       ...propOverrides,

--- a/amundsen_application/static/js/components/DashboardPage/test.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/test.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from 'components/common/LoadingSpinner';
 import Breadcrumb from 'components/common/Breadcrumb';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 import TabsComponent from 'components/common/TabsComponent';
+import ImagePreview from './ImagePreview';
 
 describe('DashboardPage', () => {
   const setup = (propOverrides?: Partial<DashboardPageProps>) => {
@@ -76,6 +77,9 @@ describe('DashboardPage', () => {
       expect(wrapper.find(BookmarkIcon).exists()).toBeTruthy();
     });
 
+    it('renders an ImagePreview with correct props', () => {
+      expect(wrapper.find(ImagePreview).props().uri).toBe(wrapper.state().uri);
+    })
   });
 
   describe('renderTabs', () => {

--- a/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.spec.tsx
@@ -53,7 +53,7 @@ describe('DashboardListItem', () => {
     it('getLink returns correct string', () => {
       const { props, wrapper } = setup();
       const { dashboard, logging } = props;
-      expect(wrapper.instance().getLink()).toEqual(`/dashboard/${dashboard.uri}?index=${logging.index}&source=${logging.source}`);
+      expect(wrapper.instance().getLink()).toEqual(`/dashboard?uri=${dashboard.uri}&index=${logging.index}&source=${logging.source}`);
     });
   });
 

--- a/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.tsx
@@ -26,7 +26,7 @@ class DashboardListItem extends React.Component<DashboardListItemProps, {}> {
 
   getLink = () => {
     const { dashboard, logging } = this.props;
-    return `/dashboard/${dashboard.uri}?index=${logging.index}&source=${logging.source}`;
+    return `/dashboard?uri=${dashboard.uri}&index=${logging.index}&source=${logging.source}`;
   };
 
   render() {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
@@ -7,11 +7,11 @@ export interface ResultItemProps {
   iconClass: string;
   onItemSelect: (event: MouseEvent) => void;
   subtitle: string;
-  title: React.ReactNode;
+  titleNode: React.ReactNode;
   type: string;
 }
 
-const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, id, onItemSelect, subtitle, title, type }) => {
+const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, id, onItemSelect, subtitle, titleNode, type }) => {
   return (
     <li className="list-group-item">
       <Link id={id} className="result-item-link" onClick={onItemSelect} to={ href }>
@@ -19,7 +19,7 @@ const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, id, onItemSel
 
         <div className="result-info">
           <div className="truncated">
-            { title }
+            { titleNode }
             <div className="body-secondary-3 truncated">{ subtitle }</div>
           </div>
         </div>

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/tests/index.spec.tsx
@@ -16,7 +16,7 @@ describe('ResultItem', () => {
       iconClass: 'test-icon',
       onItemSelect: jest.fn(),
       subtitle: 'subtitle',
-      title: (<div>Hello</div>),
+      titleNode: (<div>Hello</div>),
       type: 'User',
     };
     subject = shallow(<ResultItem {...props} />);
@@ -52,7 +52,7 @@ describe('ResultItem', () => {
 
       it('renders the title', () => {
         // @ts-ignore: assertion passes but throws a TS error
-        expect(contentWrapper.children().at(0).text()).toEqual(shallow(props.title).text());
+        expect(contentWrapper.children().at(0).text()).toEqual(shallow(props.titleNode).text());
       });
 
       it('renders the subtitle', () => {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/index.tsx
@@ -12,7 +12,7 @@ export interface ResultItemListProps {
   resourceType: ResourceType;
   searchTerm: string;
   suggestedResults: SuggestedResult[];
-  title: React.ReactNode;
+  title: string;
   totalResults: number;
 }
 
@@ -38,7 +38,7 @@ class ResultItemList extends React.Component<ResultItemListProps, {}> {
     }
 
     return results.map((item, index) => {
-      const { href, iconClass, subtitle, title, type } = item;
+      const { href, iconClass, subtitle, titleNode, type } = item;
       const id = `inline-resultitem-${this.props.resourceType}:${index}`;
       return (
         <ResultItem
@@ -48,7 +48,7 @@ class ResultItemList extends React.Component<ResultItemListProps, {}> {
           onItemSelect={onResultItemSelect}
           iconClass={`icon icon-dark ${iconClass}`}
           subtitle={subtitle}
-          title={title}
+          titleNode={titleNode}
           type={type}
         />
       )

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/tests/index.spec.tsx
@@ -26,14 +26,14 @@ describe('ResultItemList', () => {
           href: '/test',
           iconClass: 'test-icon',
           subtitle: 'subtitle',
-          title: 'title',
+          titleNode: 'title',
           type: 'Hive',
         },
         {
           href: '/test2',
           iconClass: 'test-icon',
           subtitle: 'subtitle2',
-          title: 'title2',
+          titleNode: 'title2',
           type: 'Hive',
         }
       ],
@@ -68,12 +68,12 @@ describe('ResultItemList', () => {
       const listItems = wrapper.instance().renderResultItems(props.suggestedResults);
       const expectedOnItemSelect = props.onItemSelect(props.resourceType);
       listItems.forEach((item, index) => {
-        const { href, iconClass, subtitle, title, type } = props.suggestedResults[index];
+        const { href, iconClass, subtitle, titleNode, type } = props.suggestedResults[index];
         expect(item.props.href).toBe(href);
         expect(item.props.onItemSelect()).toBe(expectedOnItemSelect);
         expect(item.props.iconClass).toBe(`icon icon-dark ${iconClass}`);
         expect(item.props.subtitle).toBe(subtitle);
-        expect(item.props.title).toBe(title);
+        expect(item.props.titleNode).toBe(titleNode);
         expect(item.props.type).toBe(type);
       });
     })

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
@@ -34,7 +34,7 @@ export interface SuggestedResult {
   href: string;
   iconClass: string;
   subtitle: string;
-  title: React.ReactNode;
+  titleNode: React.ReactNode;
   type: string;
 }
 
@@ -89,7 +89,7 @@ export class InlineSearchResults extends React.Component<InlineSearchResultsProp
         href: this.getSuggestedResultHref(resourceType, result, index),
         iconClass: this.getSuggestedResultIconClass(resourceType, result),
         subtitle: this.getSuggestedResultSubTitle(resourceType, result),
-        title: this.getSuggestedResultTitle(resourceType, result),
+        titleNode: this.getSuggestedResultTitle(resourceType, result),
         type: this.getSuggestedResultType(resourceType, result)
       }
     });

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/index.tsx
@@ -100,7 +100,7 @@ export class InlineSearchResults extends React.Component<InlineSearchResultsProp
     switch (resourceType) {
       case ResourceType.dashboard:
         const dashboard = result as DashboardResource;
-        return `/dashboard/${dashboard.uri}?${logParams}`;
+        return `/dashboard?uri=${dashboard.uri}&${logParams}`;
       case ResourceType.table:
         const table = result as TableResource;
         return `/table_detail/${table.cluster}/${table.database}/${table.schema}/${table.name}?${logParams}`;

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
@@ -188,7 +188,7 @@ describe('InlineSearchResults', () => {
       const index = 0;
       const givenDashboard = props.dashboards.results[index];
       const output = wrapper.instance().getSuggestedResultHref(ResourceType.dashboard, givenDashboard, index);
-      expect(output).toEqual(`/dashboard/${givenDashboard.uri}?source=inline_search&index=${index}`);
+      expect(output).toEqual(`/dashboard?uri=${givenDashboard.uri}&source=inline_search&index=${index}`);
     });
     it('returns the correct href for ResourceType.table', () => {
       const index = 0;

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/tests/index.spec.tsx
@@ -170,7 +170,7 @@ describe('InlineSearchResults', () => {
         expect(result.href).toEqual(mockHref);
         expect(result.iconClass).toEqual(mockClass);
         expect(result.subtitle).toEqual(mockSubtitle);
-        expect(result.title).toEqual(mockTitle);
+        expect(result.titleNode).toEqual(mockTitle);
         expect(result.type).toEqual(mockType);
       });
     });

--- a/amundsen_application/static/js/ducks/dashboard/api/v0.spec.ts
+++ b/amundsen_application/static/js/ducks/dashboard/api/v0.spec.ts
@@ -1,0 +1,51 @@
+import axios, { AxiosResponse } from 'axios';
+
+import * as API from './v0';
+
+jest.mock('axios');
+
+describe('getDashboardPreview', () => {
+  let axiosMockGet;
+  let testUri;
+  let expectedImageSrc;
+  beforeAll(() => {
+    testUri = 'someUri';
+    expectedImageSrc = `${API.DASHBOARD_PREVIEW_BASE}/${testUri}/preview.jpg`;
+  })
+
+  it('resolves with object with expected url on success', async () => {
+    expect.assertions(1);
+    axiosMockGet = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve());
+    await API.getDashboardPreview(testUri).then(payload => {
+      expect(payload).toEqual({ url: expectedImageSrc });
+    });
+  });
+
+  it('resolves with object with expected url and error infor on failure', async () => {
+    expect.assertions(1);
+    const mockMessage = 'Something bad happened';
+    const mockStatus = 500;
+    const mockErrorResponse = {
+      response: {
+        data: {
+         msg: mockMessage
+        },
+        status: mockStatus,
+        statusText: '',
+        headers: {},
+        config: {}
+      }
+    };
+    axiosMockGet = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.reject(mockErrorResponse));
+    try {
+      const payload = await API.getDashboardPreview(testUri);
+    }
+    catch(errorPayload) {
+      expect(errorPayload).toEqual({
+        url: expectedImageSrc,
+        errorCode: mockStatus,
+        errorMessage: mockMessage
+      });
+    }
+  });
+});

--- a/amundsen_application/static/js/ducks/dashboard/api/v0.ts
+++ b/amundsen_application/static/js/ducks/dashboard/api/v0.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosResponse, AxiosPromise } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
+import { DashboardPreviewResponse } from 'ducks/dashboard/types';
 import { Dashboard } from 'interfaces/Dashboard';
 
 export type GetDashboardAPI = {
@@ -7,11 +8,6 @@ export type GetDashboardAPI = {
   dashboard: Dashboard;
 }
 
-export type DashboardPreviewResponse = {
-  url: string;
-  errorMessage?: string;
-  errorCode?: number;
-}
 
 const DASHBOARD_BASE = '/api/dashboard/v0';
 const DASHBOARD_PREVIEW_BASE = '/api/dashboard_preview/v0/dashboard'
@@ -33,7 +29,7 @@ export function getDashboardPreview(uri: string): Promise<DashboardPreviewRespon
   })
   .catch((e) => {
     const response = e.response;
-    const errorMessage = response ? (response.data ? response.data.msg : '') : '';
+    const errorMessage = response ? (response.data ? response.data.msg : undefined) : undefined;
     const errorCode = response ? (response.status || 500) : 500;
     return Promise.reject({
       errorCode,

--- a/amundsen_application/static/js/ducks/dashboard/api/v0.ts
+++ b/amundsen_application/static/js/ducks/dashboard/api/v0.ts
@@ -8,9 +8,8 @@ export type GetDashboardAPI = {
   dashboard: Dashboard;
 }
 
-
 const DASHBOARD_BASE = '/api/dashboard/v0';
-const DASHBOARD_PREVIEW_BASE = '/api/dashboard_preview/v0/dashboard'
+export const DASHBOARD_PREVIEW_BASE = '/api/dashboard_preview/v0/dashboard'
 
 export function getDashboard(uri: string) {
   return axios.get(`${DASHBOARD_BASE}/dashboard?uri=${uri}`)

--- a/amundsen_application/static/js/ducks/dashboard/api/v0.ts
+++ b/amundsen_application/static/js/ducks/dashboard/api/v0.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse, AxiosPromise } from 'axios';
 
 import { Dashboard } from 'interfaces/Dashboard';
 
@@ -7,11 +7,38 @@ export type GetDashboardAPI = {
   dashboard: Dashboard;
 }
 
+export type DashboardPreviewResponse = {
+  url: string;
+  errorMessage?: string;
+  errorCode?: number;
+}
+
 const DASHBOARD_BASE = '/api/dashboard/v0';
+const DASHBOARD_PREVIEW_BASE = '/api/dashboard_preview/v0/dashboard'
 
 export function getDashboard(uri: string) {
   return axios.get(`${DASHBOARD_BASE}/dashboard?uri=${uri}`)
   .then((response: AxiosResponse<GetDashboardAPI>) => {
     return response.data.dashboard;
+  });
+}
+
+export function getDashboardPreview(uri: string): Promise<DashboardPreviewResponse> {
+  const imageSrc = `${DASHBOARD_PREVIEW_BASE}/${uri}/preview.jpg`;
+  return axios.get(imageSrc)
+  .then((response) => {
+    return {
+      url: imageSrc
+    };
+  })
+  .catch((e) => {
+    const response = e.response;
+    const errorMessage = response ? (response.data ? response.data.msg : '') : '';
+    const errorCode = response ? (response.status || 500) : 500;
+    return Promise.reject({
+      errorCode,
+      errorMessage,
+      url: imageSrc,
+    })
   });
 }

--- a/amundsen_application/static/js/ducks/dashboard/reducer.ts
+++ b/amundsen_application/static/js/ducks/dashboard/reducer.ts
@@ -1,4 +1,11 @@
-import { GetDashboard, GetDashboardRequest } from 'ducks/dashboard/types';
+import {
+  GetDashboard,
+  GetDashboardRequest,
+  GetDashboardPreview,
+  GetDashboardPreviewRequest,
+  GetDashboardPreviewResponse,
+  DashboardPreviewResponse,
+} from 'ducks/dashboard/types';
 import { Dashboard } from 'interfaces/Dashboard';
 
 
@@ -26,32 +33,29 @@ export function getDashboardSuccess(dashboard) {
   }
 }
 
-export function getDashboardPreview(payload: { uri: string }): any {
+export function getDashboardPreview(payload: { uri: string }): GetDashboardPreviewRequest {
   return {
     payload,
-    type: 'GETPREVIEW',
+    type: GetDashboardPreview.REQUEST,
   }
 }
 
-export function setDashboardPreview(payload: any): any {
+export function setDashboardPreview(payload: DashboardPreviewResponse): GetDashboardPreviewResponse {
   return {
     payload,
-    type: 'SETPREVIEW',
+    type: GetDashboardPreview.RESPONSE,
   }
 }
 
 
 /* Reducer */
-
+interface DashboardPreviewState extends DashboardPreviewResponse {
+  isLoading: boolean;
+}
 export interface DashboardReducerState {
   isLoading: boolean;
   dashboard: Dashboard;
-  preview: {
-    url: string;
-    errorMessage?: string;
-    errorCode?: number;
-    isLoading: boolean;
-  }
+  preview: DashboardPreviewState;
 }
 
 export const initialDashboardState: Dashboard = {
@@ -102,7 +106,7 @@ export default function reducer(state: DashboardReducerState = initialState, act
         isLoading: false,
         dashboard: action.payload.dashboard,
       };
-    case 'GETPREVIEW':
+    case GetDashboardPreview.REQUEST:
       return {
         ...state,
         preview: {
@@ -110,7 +114,7 @@ export default function reducer(state: DashboardReducerState = initialState, act
           isLoading: true,
         }
       };
-    case 'SETPREVIEW':
+    case GetDashboardPreview.RESPONSE:
       return {
         ...state,
         preview: {

--- a/amundsen_application/static/js/ducks/dashboard/reducer.ts
+++ b/amundsen_application/static/js/ducks/dashboard/reducer.ts
@@ -26,12 +26,32 @@ export function getDashboardSuccess(dashboard) {
   }
 }
 
+export function getDashboardPreview(payload: { uri: string }): any {
+  return {
+    payload,
+    type: 'GETPREVIEW',
+  }
+}
+
+export function setDashboardPreview(payload: any): any {
+  return {
+    payload,
+    type: 'SETPREVIEW',
+  }
+}
+
 
 /* Reducer */
 
 export interface DashboardReducerState {
   isLoading: boolean;
   dashboard: Dashboard;
+  preview: {
+    url: string;
+    errorMessage?: string;
+    errorCode?: number;
+    isLoading: boolean;
+  }
 }
 
 export const initialDashboardState: Dashboard = {
@@ -57,6 +77,10 @@ export const initialDashboardState: Dashboard = {
 export const initialState: DashboardReducerState = {
   isLoading: true,
   dashboard: initialDashboardState,
+  preview: {
+    url: '',
+    isLoading: true,
+  }
 };
 
 export default function reducer(state: DashboardReducerState = initialState, action): DashboardReducerState {
@@ -77,6 +101,22 @@ export default function reducer(state: DashboardReducerState = initialState, act
         ...state,
         isLoading: false,
         dashboard: action.payload.dashboard,
+      };
+    case 'GETPREVIEW':
+      return {
+        ...state,
+        preview: {
+          url: '',
+          isLoading: true,
+        }
+      };
+    case 'SETPREVIEW':
+      return {
+        ...state,
+        preview: {
+          ...action.payload,
+          isLoading: false,
+        }
       };
     default:
       return state;

--- a/amundsen_application/static/js/ducks/dashboard/sagas.ts
+++ b/amundsen_application/static/js/ducks/dashboard/sagas.ts
@@ -2,7 +2,7 @@ import { SagaIterator } from 'redux-saga';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import * as API from './api/v0';
-import { getDashboardSuccess, getDashboardFailure } from './reducer';
+import { getDashboardSuccess, getDashboardFailure, setDashboardPreview } from './reducer';
 import { GetDashboard } from './types';
 
 export function* getDashboardWorker(action): SagaIterator {
@@ -17,4 +17,17 @@ export function* getDashboardWorker(action): SagaIterator {
 
 export function* getDashboardWatcher(): SagaIterator {
   yield takeEvery(GetDashboard.REQUEST, getDashboardWorker);
+}
+
+export function* getDashboardPreviewWorker(action): SagaIterator {
+  try {
+    const payload = yield call(API.getDashboardPreview, action.payload.uri);
+    yield put(setDashboardPreview(payload));
+  } catch (error) {
+    yield put(setDashboardPreview(error));
+  }
+}
+
+export function* getDashboardPreviewWatcher(): SagaIterator {
+  yield takeEvery('GETPREVIEW', getDashboardPreviewWorker);
 }

--- a/amundsen_application/static/js/ducks/dashboard/sagas.ts
+++ b/amundsen_application/static/js/ducks/dashboard/sagas.ts
@@ -3,7 +3,7 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 
 import * as API from './api/v0';
 import { getDashboardSuccess, getDashboardFailure, setDashboardPreview } from './reducer';
-import { GetDashboard } from './types';
+import { GetDashboard, GetDashboardPreview, GetDashboardPreviewRequest } from './types';
 
 export function* getDashboardWorker(action): SagaIterator {
   try {
@@ -19,15 +19,19 @@ export function* getDashboardWatcher(): SagaIterator {
   yield takeEvery(GetDashboard.REQUEST, getDashboardWorker);
 }
 
-export function* getDashboardPreviewWorker(action): SagaIterator {
+export function* getDashboardPreviewWorker(action: GetDashboardPreviewRequest): SagaIterator {
   try {
     const payload = yield call(API.getDashboardPreview, action.payload.uri);
     yield put(setDashboardPreview(payload));
   } catch (error) {
+    /*
+      For this case the api call caught and parsed the error response into the shape the application
+      needs, and has returned that payload.
+    */
     yield put(setDashboardPreview(error));
   }
 }
 
 export function* getDashboardPreviewWatcher(): SagaIterator {
-  yield takeEvery('GETPREVIEW', getDashboardPreviewWorker);
+  yield takeEvery(GetDashboardPreview.REQUEST, getDashboardPreviewWorker);
 }

--- a/amundsen_application/static/js/ducks/dashboard/tests/reducer.spec.ts
+++ b/amundsen_application/static/js/ducks/dashboard/tests/reducer.spec.ts
@@ -1,0 +1,41 @@
+import reducer, {
+  getDashboardPreview,
+  setDashboardPreview,
+  initialState,
+  DashboardReducerState,
+} from '../reducer';
+
+import { errorPreviewStateWithMessage, successPreviewState} from 'fixtures/dashboard/preview';
+
+describe('dashboard reducer', () => {
+  let testState: DashboardReducerState;
+  beforeAll(() => {
+    testState = {
+      ...initialState,
+      preview: successPreviewState
+    }
+  });
+  it('should return the existing state if action is not handled', () => {
+    expect(reducer(testState, { type: 'INVALID.ACTION' })).toEqual(testState);
+  });
+
+ it('should handle GetDashboardPreview.REQUEST', () => {
+    expect(reducer(testState, getDashboardPreview({ uri: 'someUri' }))).toEqual({
+      ...testState,
+      preview: {
+        url: '',
+        isLoading: true,
+      }
+    });
+  });
+
+  it('should handle GetDashboardPreview.RESPONSE', () => {
+    expect(reducer(testState, setDashboardPreview(errorPreviewStateWithMessage))).toEqual({
+      ...testState,
+      preview: {
+        ...errorPreviewStateWithMessage,
+        isLoading: false,
+      }
+    });
+  });
+});

--- a/amundsen_application/static/js/ducks/dashboard/tests/sagas.spec.ts
+++ b/amundsen_application/static/js/ducks/dashboard/tests/sagas.spec.ts
@@ -1,0 +1,46 @@
+import { testSaga } from 'redux-saga-test-plan';
+
+import {
+  GetDashboardPreview
+} from '../types';
+
+import {
+  getDashboardPreview,
+  setDashboardPreview
+} from '../reducer';
+
+import { errorPreviewResponse, successPreviewResponse } from 'fixtures/dashboard/preview';
+
+import * as API from '../api/v0';
+import * as Sagas from '../sagas';
+
+describe('dashboard sagas', () => {
+  describe('getDashboardPreviewWatcher', () => {
+    it('takes GetDashboardPreview.REQUEST with getDashboardWorker', () => {
+      testSaga(Sagas.getDashboardPreviewWatcher)
+        .next().takeEvery(GetDashboardPreview.REQUEST, Sagas.getDashboardPreviewWorker)
+        .next().isDone();
+    });
+  });
+
+  describe('getDashboardPreviewWorker', () => {
+    it('handles success payload', () => {
+      const testUri = 'someUri';
+      const action = getDashboardPreview({ uri: testUri });
+      testSaga(Sagas.getDashboardPreviewWorker, action)
+        .next().call(API.getDashboardPreview, testUri)
+        .next(successPreviewResponse).put(setDashboardPreview(successPreviewResponse))
+        .next().isDone();
+    });
+
+    it('handles request error', () => {
+      const testUri = 'someUri';
+      const action = getDashboardPreview({ uri: testUri });
+      testSaga(Sagas.getDashboardPreviewWorker, action)
+        .next().call(API.getDashboardPreview, testUri)
+        // @ts-ignore: TypeScript wants trhe mocked error response to match the Error object
+        .throw(errorPreviewResponse).put(setDashboardPreview(errorPreviewResponse))
+        .next().isDone();
+    });
+  });
+});

--- a/amundsen_application/static/js/ducks/dashboard/types.ts
+++ b/amundsen_application/static/js/ducks/dashboard/types.ts
@@ -21,3 +21,23 @@ export interface GetDashboardResponse {
     dashboard: Dashboard;
   }
 }
+
+export enum GetDashboardPreview {
+  REQUEST = 'amundsen/dashboard/GET_DASHBOARD_PREVIEW_REQUEST',
+  RESPONSE = 'amundsen/dashboard/GET_DASHBOARD_PREVIEW_RESPONSE',
+}
+export interface GetDashboardPreviewRequest {
+  type: GetDashboardPreview.REQUEST;
+  payload: {
+    uri: string;
+  }
+}
+export interface GetDashboardPreviewResponse {
+  type: GetDashboardPreview.RESPONSE;
+  payload: DashboardPreviewResponse;
+}
+export interface DashboardPreviewResponse {
+  url: string;
+  errorMessage?: string | undefined;
+  errorCode?: number;
+}

--- a/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/amundsen_application/static/js/ducks/rootSaga.ts
@@ -13,6 +13,7 @@ import {
 // Dashboard
 import {
   getDashboardWatcher,
+  getDashboardPreviewWatcher,
 } from "ducks/dashboard/sagas";
 
 // Notifications
@@ -73,6 +74,7 @@ export default function* rootSaga() {
     removeBookmarkWatcher(),
     // Dashboard
     getDashboardWatcher(),
+    getDashboardPreviewWatcher(),
     // Notification
     submitNotificationWatcher(),
     // FeedbackForm

--- a/amundsen_application/static/js/fixtures/dashboard/preview.ts
+++ b/amundsen_application/static/js/fixtures/dashboard/preview.ts
@@ -1,0 +1,12 @@
+export const errorPreviewStateWithMessage = {
+  url: 'some url',
+  errorCode: 500,
+  errorMessage: 'preview error',
+  isLoading: false,
+};
+
+export const errorPreviewStateNoMessage = {
+  url: 'some url',
+  errorCode: 500,
+  isLoading: false,
+};

--- a/amundsen_application/static/js/fixtures/dashboard/preview.ts
+++ b/amundsen_application/static/js/fixtures/dashboard/preview.ts
@@ -1,3 +1,18 @@
+export const successPreviewResponse = {
+  url: 'some url',
+};
+
+export const errorPreviewResponse = {
+  url: 'some url',
+  errorCode: 500,
+  errorMessage: 'preview error',
+};
+
+export const successPreviewState = {
+  url: 'some url',
+  isLoading: false,
+};
+
 export const errorPreviewStateWithMessage = {
   url: 'some url',
   errorCode: 500,

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -53,6 +53,10 @@ const globalState: GlobalState = {
       tables: [],
       tags: [],
     },
+    preview: {
+      url: '',
+      isLoading: false,
+    }
   },
   feedback: {
     sendState: SendingState.IDLE,


### PR DESCRIPTION
### Summary of Changes

This PR adds the UI support for dashboard previews. There is also some code cleanup from https://github.com/lyft/amundsenfrontendlibrary/pull/424

#### Dashboard Preview UI
1. Created an `ImagePreview` component and added it to `DashboardPage`. This component supports showing the url if it exists, and supports showing error messages from the API if the request fails.
2. Added support in `ducks` to request the dashboard image preview. This is a special case where we already know what the url for each resource us going to be -- so the success response just returns that url, and the failure case has to do some extra parsing of the response to additionally return the error code and error message for the UI.

#### Code Cleanup
1. Updated the links to `DashboardPage` to put the `uri` in the search params
2. Resolved issue of `title` vs `titleNode` when the property is a `React.ReactNode`.

#### Future Work
1. `ImagePreview` loading state is intended to use the shimmer effect design.
2. The design or api or implementation that supports this should be revisited -- the issue is that because Redux calls the API to support knowing when a component is ready to load *and* the `<img>` tag  requests its `src` when it renders we double request the image. When connections are slow, this results in a slight pause where neither the loading UI nor the image shows up and the UI will be blank for quick moment.

### Tests

Added test to cover main functionality of new code.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
