### PR TITLE
Dashboard Bookmarks & Dashboard ProfilePage support

### DIFF
--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -552,8 +552,14 @@ def get_user_own() -> Response:
         status_code = response.status_code
         owned_tables_raw = response.json().get('table')
         owned_tables = [marshall_table_partial(table) for table in owned_tables_raw]
-        return make_response(jsonify({'msg': 'success', 'own': owned_tables}), status_code)
-
+        # TODO: use common to create marshall_dashboard_partial
+        dashboards = response.json().get('dashboard', [])
+        owned_dashboards = [map_dashboard_result(dashboard) for dashboard in dashboards]
+        all_owned = {
+            'table': owned_tables,
+            'dashboard': owned_dashboards
+        }
+        return make_response(jsonify({'msg': 'success', 'own': all_owned}), status_code)
     except Exception as e:
         message = 'Encountered exception: ' + str(e)
         logging.exception(message)

--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -12,6 +12,7 @@ from amundsen_application.log.action_log import action_logging
 from amundsen_application.models.user import load_user, dump_user
 
 from amundsen_application.api.utils.metadata_utils import marshall_table_partial, marshall_table_full
+from amundsen_application.api.utils.search_utils import map_dashboard_result
 from amundsen_application.api.utils.request_utils import get_query_param, request_metadata
 
 
@@ -449,12 +450,20 @@ def get_bookmark() -> Response:
             message = 'Success'
             tables = response.json().get('table')
             table_bookmarks = [marshall_table_partial(table) for table in tables]
+            # TODO: use common to create marshall_dashboard_partial
+            dashboards = response.json().get('dashboard', [])
+            dashboard_bookmarks = [map_dashboard_result(dashboard) for dashboard in dashboards]
         else:
             message = f'Encountered error: failed to get bookmark for user_id: {user_id}'
             logging.error(message)
             table_bookmarks = []
+            dashboard_bookmarks = []
 
-        return make_response(jsonify({'msg': message, 'bookmarks': table_bookmarks}), status_code)
+        all_bookmarks = {
+            'table': table_bookmarks,
+            'dashboard': dashboard_bookmarks
+        }
+        return make_response(jsonify({'msg': message, 'bookmarks': all_bookmarks}), status_code)
     except Exception as e:
         message = 'Encountered exception: ' + str(e)
         logging.exception(message)

--- a/amundsen_application/api/utils/search_utils.py
+++ b/amundsen_application/api/utils/search_utils.py
@@ -25,6 +25,9 @@ def map_dashboard_result(result: Dict) -> Dict:
         'product': result.get('product', ''),
         'uri': result.get('uri', ''),
         'url': result.get('url', ''),
+        # TODO: Bookmark logic relies on key, opting to add this here to avoid messy logic in
+        # React app and we have to clean up later.
+        'key': result.get('uri', ''),
     }
 
 

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -19,6 +19,8 @@ import { Dashboard } from 'interfaces/Dashboard';
 import QueryList from 'components/DashboardPage/QueryList';
 import ChartList from 'components/DashboardPage/ChartList';
 
+import { ResourceType } from 'interfaces';
+
 export interface RouteProps {
   uri: string;
 }
@@ -93,7 +95,7 @@ export class DashboardPage extends React.Component<DashboardPageProps, Dashboard
             <h3 className="header-title-text truncated">
               { dashboard.name }
             </h3>
-            <BookmarkIcon bookmarkKey={ '' }/>
+            <BookmarkIcon bookmarkKey={ dashboard.uri } resourceType={ ResourceType.dashboard } />
             <div className="body-2">
               Dashboard in&nbsp;
               <a id="dashboard-group-link"

--- a/amundsen_application/static/js/components/DashboardPage/test.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/test.tsx
@@ -9,6 +9,8 @@ import Breadcrumb from 'components/common/Breadcrumb';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 import TabsComponent from 'components/common/TabsComponent';
 
+import { ResourceType } from 'interfaces';
+
 describe('DashboardPage', () => {
   const setup = (propOverrides?: Partial<DashboardPageProps>) => {
     const routerProps = getMockRouterProps<RouteProps>({ uri: 'test:uri/value' }, null);
@@ -72,8 +74,10 @@ describe('DashboardPage', () => {
       expect(headerText).toEqual(props.dashboard.name);
     });
 
-    it('renders a bookmark icon', () => {
-      expect(wrapper.find(BookmarkIcon).exists()).toBeTruthy();
+    it('renders a bookmark icon with correct props', () => {
+      const elementProps = wrapper.find(BookmarkIcon).props();
+      expect(elementProps.bookmarkKey).toBe(props.dashboard.uri);
+      expect(elementProps.resourceType).toBe(ResourceType.dashboard);
     });
 
   });

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -44,11 +44,10 @@ interface ResourceRelation {
 }
 interface StateFromProps {
   user: PeopleUser;
-  resourceRelations: any; // TODO ttannis: FIX THIS
-  // resourceRelations: {
-  //   [ResourceType.table]: ResourceRelation;
-  //   [ResourceType.dashboard]: ResourceRelation;
-  // }
+  resourceRelations: {
+     [ResourceType.table]: ResourceRelation;
+     [ResourceType.dashboard]: ResourceRelation;
+  }
 }
 
 interface DispatchFromProps {
@@ -130,15 +129,19 @@ export class ProfilePage extends React.Component<ProfilePageProps, ProfilePageSt
           customFooterText={`${FOOTER_TEXT_PREFIX} ${bookmarks.length} ${BOOKMARKED_LABEL} ${resourceLabel}`}
           customEmptyText={`${EMPTY_TEXT_PREFIX} ${BOOKMARKED_LABEL} ${resourceLabel}.`}
         />
-        <ResourceList
-          allItems={ read }
-          itemsPerPage={ ITEMS_PER_PAGE }
-          paginate={ false }
-          source={ READ_SOURCE }
-          title={`${READ_TITLE_PREFIX}  (${read.length})`}
-          customFooterText={`${FOOTER_TEXT_PREFIX} ${read.length} ${READ_LABEL} ${resourceLabel}`}
-          customEmptyText={`${EMPTY_TEXT_PREFIX} ${READ_LABEL} ${resourceLabel}.`}
-        />
+        {
+          /* Frequently Used currently not supported for dashboards */
+          resource === ResourceType.table &&
+          <ResourceList
+            allItems={ read }
+            itemsPerPage={ ITEMS_PER_PAGE }
+            paginate={ false }
+            source={ READ_SOURCE }
+            title={`${READ_TITLE_PREFIX}  (${read.length})`}
+            customFooterText={`${FOOTER_TEXT_PREFIX} ${read.length} ${READ_LABEL} ${resourceLabel}`}
+            customEmptyText={`${EMPTY_TEXT_PREFIX} ${READ_LABEL} ${resourceLabel}.`}
+          />
+        }
       </>
     )
   };
@@ -263,12 +266,12 @@ export const mapStateToProps = (state: GlobalState) => {
     resourceRelations: {
       [ResourceType.table]: {
         bookmarks: state.bookmarks.bookmarksForUser[ResourceType.table],
-        own: state.user.profile.own,
+        own: state.user.profile.own[ResourceType.table],
         read: state.user.profile.read,
       },
       [ResourceType.dashboard]: {
         bookmarks: state.bookmarks.bookmarksForUser[ResourceType.dashboard],
-        own: [],
+        own: state.user.profile.own[ResourceType.dashboard],
         read: [],
       }
     }

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -12,7 +12,7 @@ import TabsComponent from 'components/common/TabsComponent';
 
 import { GlobalState } from 'ducks/rootReducer';
 import { getUser, getUserOwn, getUserRead } from 'ducks/user/reducer';
-import { PeopleUser, Resource, ResourceType } from 'interfaces';
+import { PeopleUser, Resource, ResourceType, ResourceDict } from 'interfaces';
 import { GetUserRequest, GetUserOwnRequest, GetUserReadRequest } from 'ducks/user/types';
 
 import './styles.scss';
@@ -44,10 +44,7 @@ interface ResourceRelation {
 }
 interface StateFromProps {
   user: PeopleUser;
-  resourceRelations: {
-     [ResourceType.table]: ResourceRelation;
-     [ResourceType.dashboard]: ResourceRelation;
-  }
+  resourceRelations: ResourceDict<ResourceRelation>;
 }
 
 interface DispatchFromProps {

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -44,10 +44,11 @@ interface ResourceRelation {
 }
 interface StateFromProps {
   user: PeopleUser;
-  resourceRelations: {
-    [ResourceType.table]: ResourceRelation;
-    [ResourceType.dashboard]: ResourceRelation;
-  }
+  resourceRelations: any; // TODO ttannis: FIX THIS
+  // resourceRelations: {
+  //   [ResourceType.table]: ResourceRelation;
+  //   [ResourceType.dashboard]: ResourceRelation;
+  // }
 }
 
 interface DispatchFromProps {
@@ -261,12 +262,12 @@ export const mapStateToProps = (state: GlobalState) => {
     user: state.user.profile.user,
     resourceRelations: {
       [ResourceType.table]: {
-        bookmarks: state.bookmarks.bookmarksForUser,
+        bookmarks: state.bookmarks.bookmarksForUser[ResourceType.table],
         own: state.user.profile.own,
         read: state.user.profile.read,
       },
       [ResourceType.dashboard]: {
-        bookmarks: [],
+        bookmarks: state.bookmarks.bookmarksForUser[ResourceType.dashboard],
         own: [],
         read: [],
       }

--- a/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
@@ -200,7 +200,7 @@ describe('ProfilePage', () => {
 
     describe('for dashboard resource', () => {
       it('does not return a ResourceList for the read resourceRelations', () => {
-        content = shallow(<div>{wrapper.instance().generateTabContent(ResourceType.table)}</div>);
+        content = shallow(<div>{wrapper.instance().generateTabContent(ResourceType.dashboard)}</div>);
         expect(content.find(ResourceList).at(2).exists()).toBe(false);
       });
     });
@@ -455,13 +455,14 @@ describe('mapStateToProps', () => {
     it('sets relations for tables', () => {
       const tables = result.resourceRelations[ResourceType.table];
       expect(tables.bookmarks).toBe(globalState.bookmarks.bookmarksForUser[ResourceType.table]);
-      expect(tables.own).toBe(globalState.user.profile.own);
+      expect(tables.own).toBe(globalState.user.profile.own[ResourceType.table]);
       expect(tables.read).toBe(globalState.user.profile.read);
     });
 
     it('sets relations for dashboards', () => {
       const dashboards = result.resourceRelations[ResourceType.dashboard];
       expect(dashboards.bookmarks).toBe(globalState.bookmarks.bookmarksForUser[ResourceType.dashboard]);
+      expect(dashboards.own).toBe(globalState.user.profile.own[ResourceType.dashboard]);
     });
   });
 });

--- a/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/tests/index.spec.tsx
@@ -184,16 +184,25 @@ describe('ProfilePage', () => {
       content = shallow(<div>{wrapper.instance().generateTabContent(givenResource)}</div>);
     });
 
-    it('returns a ResourceList for the own resourceRelations', () => {
-      expect(content.find(ResourceList).at(0).props().allItems).toBe(props.resourceRelations[givenResource].own);
+    describe('for a resource', () => {
+      it('returns a ResourceList for the own resourceRelations', () => {
+        expect(content.find(ResourceList).at(0).props().allItems).toBe(props.resourceRelations[givenResource].own);
+      });
+
+      it('returns a ResourceList for the bookmarked resourceRelations', () => {
+        expect(content.find(ResourceList).at(1).props().allItems).toBe(props.resourceRelations[givenResource].bookmarks);
+      });
+
+      it('returns a ResourceList for the read resourceRelations', () => {
+        expect(content.find(ResourceList).at(2).props().allItems).toBe(props.resourceRelations[givenResource].read);
+      });
     });
 
-    it('returns a ResourceList for the bookmarked resourceRelations', () => {
-      expect(content.find(ResourceList).at(1).props().allItems).toBe(props.resourceRelations[givenResource].bookmarks);
-    });
-
-    it('returns a ResourceList for the read resourceRelations', () => {
-      expect(content.find(ResourceList).at(2).props().allItems).toBe(props.resourceRelations[givenResource].read);
+    describe('for dashboard resource', () => {
+      it('does not return a ResourceList for the read resourceRelations', () => {
+        content = shallow(<div>{wrapper.instance().generateTabContent(ResourceType.table)}</div>);
+        expect(content.find(ResourceList).at(2).exists()).toBe(false);
+      });
     });
   });
 
@@ -445,9 +454,14 @@ describe('mapStateToProps', () => {
   describe('sets resourceRelations on the props', () => {
     it('sets relations for tables', () => {
       const tables = result.resourceRelations[ResourceType.table];
-      expect(tables.bookmarks).toEqual(globalState.bookmarks.bookmarksForUser);
-      expect(tables.own).toEqual(globalState.user.profile.own);
-      expect(tables.read).toEqual(globalState.user.profile.read);
-    })
+      expect(tables.bookmarks).toBe(globalState.bookmarks.bookmarksForUser[ResourceType.table]);
+      expect(tables.own).toBe(globalState.user.profile.own);
+      expect(tables.read).toBe(globalState.user.profile.read);
+    });
+
+    it('sets relations for dashboards', () => {
+      const dashboards = result.resourceRelations[ResourceType.dashboard];
+      expect(dashboards.bookmarks).toBe(globalState.bookmarks.bookmarksForUser[ResourceType.dashboard]);
+    });
   });
 });

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -142,7 +142,7 @@ class TableDetail extends React.Component<TableDetailProps & RouteComponentProps
               <h3 className="header-title-text truncated">
                   { this.getDisplayName() }
               </h3>
-              <BookmarkIcon bookmarkKey={ this.props.tableData.key }/>
+              <BookmarkIcon bookmarkKey={ data.key } resourceType={ ResourceType.table } />
               <div className="body-2">
                 <TableHeaderBullets
                   database={ data.database }

--- a/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/index.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/index.tsx
@@ -6,6 +6,8 @@ import { addBookmark, removeBookmark } from "ducks/bookmark/reducer";
 import { AddBookmarkRequest, RemoveBookmarkRequest } from "ducks/bookmark/types";
 import { GlobalState } from "ducks/rootReducer";
 
+import { ResourceType } from 'interfaces';
+
 import './styles.scss'
 
 
@@ -14,13 +16,14 @@ interface StateFromProps {
 }
 
 interface DispatchFromProps {
-  addBookmark: (key: string, type: string) => AddBookmarkRequest,
-  removeBookmark: (key: string, type: string) => RemoveBookmarkRequest,
+  addBookmark: (key: string, type: ResourceType) => AddBookmarkRequest,
+  removeBookmark: (key: string, type: ResourceType) => RemoveBookmarkRequest,
 }
 
 interface OwnProps {
   bookmarkKey: string;
   large?: boolean;
+  resourceType: ResourceType;
 }
 
 export type BookmarkIconProps = StateFromProps & DispatchFromProps & OwnProps;
@@ -39,9 +42,9 @@ export class BookmarkIcon extends React.Component<BookmarkIconProps> {
     event.preventDefault();
 
     if (this.props.isBookmarked) {
-      this.props.removeBookmark(this.props.bookmarkKey, 'table');
+      this.props.removeBookmark(this.props.bookmarkKey, this.props.resourceType);
     } else {
-      this.props.addBookmark(this.props.bookmarkKey, 'table');
+      this.props.addBookmark(this.props.bookmarkKey, this.props.resourceType);
     }
   };
 
@@ -58,7 +61,7 @@ export class BookmarkIcon extends React.Component<BookmarkIconProps> {
 export const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
   return {
     bookmarkKey: ownProps.bookmarkKey,
-    isBookmarked: state.bookmarks.myBookmarks.some((bookmark) => bookmark.key === ownProps.bookmarkKey),
+    isBookmarked: state.bookmarks.myBookmarks[ownProps.resourceType].some((bookmark) => bookmark.key === ownProps.bookmarkKey),
   };
 };
 

--- a/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/tests/index.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+/*import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
@@ -111,4 +111,4 @@ describe('mapStateToProps', () => {
     const result = mapStateToProps(globalState, ownProps);
     expect(result.isBookmarked).toBe(true);
   });
-});
+});*/

--- a/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/BookmarkIcon/tests/index.spec.tsx
@@ -1,12 +1,12 @@
-/*import * as React from 'react';
+import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
 import globalState from 'fixtures/globalState';
 
+import { ResourceType } from 'interfaces';
 
 import { BookmarkIcon, BookmarkIconProps, mapDispatchToProps, mapStateToProps } from "../";
-
 
 describe('BookmarkIcon', () => {
 
@@ -17,6 +17,7 @@ describe('BookmarkIcon', () => {
       large: false,
       addBookmark: jest.fn(),
       removeBookmark: jest.fn(),
+      resourceType: ResourceType.table,
       ...propOverrides
     };
     const wrapper = shallow<BookmarkIcon>(<BookmarkIcon {...props} />);
@@ -41,7 +42,7 @@ describe('BookmarkIcon', () => {
       });
 
       wrapper.find('div').simulate('click', clickEvent);
-      expect(props.addBookmark).toHaveBeenCalled();
+      expect(props.addBookmark).toHaveBeenCalledWith(props.bookmarkKey, props.resourceType);
     });
 
     it('unbookmarks a bookmarked resource', () => {
@@ -49,7 +50,7 @@ describe('BookmarkIcon', () => {
         isBookmarked: true
       });
       wrapper.find('div').simulate('click', clickEvent);
-      expect(props.removeBookmark).toHaveBeenCalled();
+      expect(props.removeBookmark).toHaveBeenCalledWith(props.bookmarkKey, props.resourceType);
     });
   });
 
@@ -94,21 +95,21 @@ describe('mapDispatchToProps', () => {
 
 describe('mapStateToProps', () => {
   it('sets the bookmarkKey on the props', () => {
-      const ownProps = { bookmarkKey: "test_bookmark_key" };
+      const ownProps = { bookmarkKey: "test_bookmark_key", resourceType: ResourceType.table };
       const result = mapStateToProps(globalState, ownProps);
       expect(result.bookmarkKey).toEqual(ownProps.bookmarkKey);
   });
 
   it('sets isBookmarked to false when the resource key is not bookmarked', () => {
-    const ownProps = { bookmarkKey: "not_bookmarked_key" };
+    const ownProps = { bookmarkKey: "not_bookmarked_key", resourceType: ResourceType.table };
     const result = mapStateToProps(globalState, ownProps);
     expect(result.isBookmarked).toBe(false);
   });
 
 
   it('sets isBookmarked to true when the resource key is bookmarked', () => {
-    const ownProps = { bookmarkKey: "bookmarked_key" };
+    const ownProps = { bookmarkKey: "bookmarked_key", resourceType: ResourceType.table };
     const result = mapStateToProps(globalState, ownProps);
     expect(result.isBookmarked).toBe(true);
   });
-});*/
+});

--- a/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { GlobalState } from 'ducks/rootReducer';
 
 import './styles.scss'
-import { Bookmark, ResourceType } from 'interfaces';
+import { Bookmark, ResourceType, ResourceDict } from 'interfaces';
 import { getDisplayNameByResource, indexDashboardsEnabled } from 'config/config-utils';
 import {
   BOOKMARK_TITLE,
@@ -15,10 +15,7 @@ import ResourceList from 'components/common/ResourceList';
 import TabsComponent from 'components/common/TabsComponent';
 
 interface StateFromProps {
-  myBookmarks: {
-    [ResourceType.table]: Bookmark[];
-    [ResourceType.dashboard]: Bookmark[];
-  },
+  myBookmarks: ResourceDict<Bookmark[]>;
   isLoaded: boolean;
 }
 

--- a/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
@@ -93,10 +93,6 @@ export class MyBookmarks extends React.Component<MyBookmarksProps> {
 
 export const mapStateToProps = (state: GlobalState) => {
   return {
-    /*myBookmarks: {
-      [ResourceType.table]: state.bookmarks.myBookmarks,
-      [ResourceType.dashboard]: [],
-    },*/
     myBookmarks: state.bookmarks.myBookmarks,
     isLoaded: state.bookmarks.myBookmarksIsLoaded,
   };

--- a/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/index.tsx
@@ -93,10 +93,11 @@ export class MyBookmarks extends React.Component<MyBookmarksProps> {
 
 export const mapStateToProps = (state: GlobalState) => {
   return {
-    myBookmarks: {
+    /*myBookmarks: {
       [ResourceType.table]: state.bookmarks.myBookmarks,
       [ResourceType.dashboard]: [],
-    },
+    },*/
+    myBookmarks: state.bookmarks.myBookmarks,
     isLoaded: state.bookmarks.myBookmarksIsLoaded,
   };
 };

--- a/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Bookmark/MyBookmarks/tests/index.spec.tsx
@@ -255,8 +255,8 @@ describe('mapStateToProps', () => {
     result = mapStateToProps(globalState);
   });
 
-  it('sets table bookmarks on the props', () => {
-    expect(result.myBookmarks[ResourceType.table]).toEqual(globalState.bookmarks.myBookmarks);
+  it('sets bookmarks on the props', () => {
+    expect(result.myBookmarks).toEqual(globalState.bookmarks.myBookmarks);
   });
 
   it('sets myBookmarksIsLoaded on the props', () => {

--- a/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.spec.tsx
@@ -94,8 +94,10 @@ describe('DashboardListItem', () => {
         expect(resourceInfo.find('.dashboard-name').text()).toEqual(props.dashboard.name);
       });
 
-      it('renders a bookmark icon in the resource name', () => {
-        expect(resourceInfo.find('.resource-name').find(BookmarkIcon).exists()).toBe(true);
+      it('renders a bookmark icon in the resource name with correct props', () => {
+        const elementProps = resourceInfo.find('.resource-name').find(BookmarkIcon).props();
+        expect(elementProps.bookmarkKey).toBe(props.dashboard.uri);
+        expect(elementProps.resourceType).toBe(props.dashboard.type);
       });
 
       it('renders dashboard description', () => {

--- a/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/DashboardListItem/index.tsx
@@ -44,7 +44,7 @@ class DashboardListItem extends React.Component<DashboardListItemProps, {}> {
                 <div className="dashboard-name truncated">
                   { dashboard.name }
                 </div>
-                <BookmarkIcon bookmarkKey={ dashboard.uri }/>
+                <BookmarkIcon bookmarkKey={ dashboard.uri } resourceType={ dashboard.type } />
               </div>
               <div className="body-secondary-3 truncated">{ dashboard.description }</div>
             </div>

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/index.tsx
@@ -44,7 +44,7 @@ class TableListItem extends React.Component<TableListItemProps, {}> {
                 <div className="truncated">
                   { `${table.schema}.${table.name}`}
                 </div>
-                <BookmarkIcon bookmarkKey={ this.props.table.key }/>
+                <BookmarkIcon bookmarkKey={ table.key } resourceType={ table.type } />
               </div>
               <div className="body-secondary-3 truncated">{ table.description }</div>
             </div>

--- a/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/TableListItem/tests/index.spec.tsx
@@ -98,8 +98,10 @@ describe('TableListItem', () => {
         expect(resourceInfo.find('.resource-name').children().at(0).text()).toEqual('tableSchema.tableName');
       });
 
-      it('renders a bookmark icon in the resource name', () => {
-        expect(resourceInfo.find('.resource-name').find(BookmarkIcon).exists()).toBe(true);
+      it('renders a bookmark icon in the resource name with correct props', () => {
+        const elementProps = resourceInfo.find('.resource-name').find(BookmarkIcon).props();
+        expect(elementProps.bookmarkKey).toBe(props.table.key);
+        expect(elementProps.resourceType).toBe(props.table.type);
       });
 
       it('renders table description', () => {

--- a/amundsen_application/static/js/ducks/bookmark/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/bookmark/api/tests/index.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 
-import { Bookmark } from 'interfaces';
+import { Bookmark, ResourceType } from 'interfaces';
 
 import * as API from '../v0';
 
@@ -25,14 +25,16 @@ describe('addBookmark', () => {
 
   it('calls axios with correct parameters', async () => {
     expect.assertions(1);
-    await API.addBookmark('test', 'table').then(data => {
-      expect(axiosMock).toHaveBeenCalledWith(`${API.API_PATH}/user/bookmark`, { type: 'table', key: 'test' });
+    const givenResource = ResourceType.table;
+    await API.addBookmark('test', givenResource).then(data => {
+      expect(axiosMock).toHaveBeenCalledWith(`${API.API_PATH}/user/bookmark`, { type: givenResource, key: 'test' });
     });
   });
 
   it('returns response data', async () => {
     expect.assertions(1);
-    await API.addBookmark('test', 'table').then(data => {
+    const givenResource = ResourceType.table;
+    await API.addBookmark('test', givenResource).then(data => {
       expect(data).toEqual(mockPutResponse.data);
     });
   });
@@ -105,14 +107,16 @@ describe('removeBookmark', () => {
 
   it('calls axios with correct parameters', async () => {
     expect.assertions(1);
-    await API.removeBookmark('testKey', 'table').then(data => {
-      expect(axiosMock).toHaveBeenCalledWith(`${API.API_PATH}/user/bookmark`, { data: { type: 'table', key: 'testKey' }});
+    const givenResource = ResourceType.table;
+    await API.removeBookmark('testKey', givenResource).then(data => {
+      expect(axiosMock).toHaveBeenCalledWith(`${API.API_PATH}/user/bookmark`, { data: { type: givenResource, key: 'testKey' }});
     });
   });
 
   it('returns response data', async () => {
     expect.assertions(1);
-    await API.removeBookmark('test', 'table').then(data => {
+    const givenResource = ResourceType.table;
+    await API.removeBookmark('test', givenResource).then(data => {
       expect(data).toEqual(mockDeleteResponse.data);
     });
   });

--- a/amundsen_application/static/js/ducks/bookmark/api/v0.ts
+++ b/amundsen_application/static/js/ducks/bookmark/api/v0.ts
@@ -1,17 +1,19 @@
 import axios, { AxiosResponse } from 'axios';
 
+import { ResourceType } from 'interfaces';
+
 export const API_PATH = '/api/metadata/v0';
 // TODO - Consider moving 'Bookmarks' under 'User'
 // TODO: Define types for the AxiosResponse data
 
-export function addBookmark(resourceKey: string, resourceType: string) {
+export function addBookmark(resourceKey: string, resourceType: ResourceType) {
   return axios.put(`${API_PATH}/user/bookmark`, { type: resourceType, key: resourceKey })
     .then((response: AxiosResponse) => {
       return response.data;
     });
 }
 
-export function removeBookmark(resourceKey: string, resourceType: string) {
+export function removeBookmark(resourceKey: string, resourceType: ResourceType) {
   return axios.delete(`${API_PATH}/user/bookmark`, { data: { type: resourceType, key: resourceKey }})
     .then((response: AxiosResponse) => {
       return response.data;

--- a/amundsen_application/static/js/ducks/bookmark/reducer.ts
+++ b/amundsen_application/static/js/ducks/bookmark/reducer.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from 'interfaces';
+import { Bookmark, ResourceType } from 'interfaces';
 
 import {
   AddBookmark,
@@ -16,7 +16,7 @@ import {
 } from './types';
 
 /* ACTIONS */
-export function addBookmark(resourceKey: string, resourceType: string): AddBookmarkRequest {
+export function addBookmark(resourceKey: string, resourceType: ResourceType): AddBookmarkRequest {
   return {
     payload: {
       resourceKey,
@@ -28,11 +28,11 @@ export function addBookmark(resourceKey: string, resourceType: string): AddBookm
 export function addBookmarkFailure(): AddBookmarkResponse {
   return { type: AddBookmark.FAILURE };
 }
-export function addBookmarkSuccess(bookmarks: Bookmark[]): AddBookmarkResponse {
+export function addBookmarkSuccess(bookmarks: BookmarkState): AddBookmarkResponse {
   return { type: AddBookmark.SUCCESS, payload: { bookmarks } };
 }
 
-export function removeBookmark(resourceKey: string, resourceType: string): RemoveBookmarkRequest {
+export function removeBookmark(resourceKey: string, resourceType: ResourceType): RemoveBookmarkRequest {
   return {
     payload: {
       resourceKey,
@@ -44,7 +44,7 @@ export function removeBookmark(resourceKey: string, resourceType: string): Remov
 export function removeBookmarkFailure(): RemoveBookmarkResponse {
   return { type: RemoveBookmark.FAILURE };
 }
-export function removeBookmarkSuccess(resourceKey: string, resourceType: string): RemoveBookmarkResponse {
+export function removeBookmarkSuccess(resourceKey: string, resourceType: ResourceType): RemoveBookmarkResponse {
   return { type: RemoveBookmark.SUCCESS, payload: { resourceKey, resourceType } };
 }
 
@@ -54,9 +54,9 @@ export function getBookmarks(): GetBookmarksRequest {
   }
 }
 export function getBookmarksFailure(): GetBookmarksResponse {
-  return { type: GetBookmarks.FAILURE, payload: { bookmarks: [] } };
+  return { type: GetBookmarks.FAILURE };
 }
-export function getBookmarksSuccess(bookmarks: Bookmark[]): GetBookmarksResponse {
+export function getBookmarksSuccess(bookmarks: BookmarkState): GetBookmarksResponse {
   return { type: GetBookmarks.SUCCESS, payload: { bookmarks } };
 }
 
@@ -69,23 +69,34 @@ export function getBookmarksForUser(userId: string): GetBookmarksForUserRequest 
   }
 }
 export function getBookmarksForUserFailure(): GetBookmarksForUserResponse {
-  return { type: GetBookmarksForUser.FAILURE, payload: { bookmarks: [] } };
+  return { type: GetBookmarksForUser.FAILURE };
 }
-export function getBookmarksForUserSuccess(bookmarks: Bookmark[]): GetBookmarksForUserResponse {
+export function getBookmarksForUserSuccess(bookmarks: BookmarkState): GetBookmarksForUserResponse {
   return { type: GetBookmarksForUser.SUCCESS, payload: { bookmarks } };
 }
 
 /* REDUCER */
-export interface BookmarkReducerState {
-  myBookmarks: Bookmark[];
-  myBookmarksIsLoaded: boolean;
-  bookmarksForUser: Bookmark[];
+export interface BookmarkState {
+  [ResourceType.table]: Bookmark[],
+  [ResourceType.dashboard]: Bookmark[],
 }
-
+export interface BookmarkReducerState {
+  myBookmarks: BookmarkState;
+  myBookmarksIsLoaded: boolean;
+  bookmarksForUser: BookmarkState;
+}
+export const initialBookmarkState = {
+  [ResourceType.table]: [],
+  [ResourceType.dashboard]: [],
+}
 export const initialState: BookmarkReducerState = {
-  myBookmarks: [],
+  myBookmarks: {
+    ...initialBookmarkState
+  },
   myBookmarksIsLoaded: false,
-  bookmarksForUser: [],
+  bookmarksForUser: {
+    ...initialBookmarkState,
+  },
 };
 
 export default function reducer(state: BookmarkReducerState = initialState, action): BookmarkReducerState {
@@ -100,7 +111,9 @@ export default function reducer(state: BookmarkReducerState = initialState, acti
     case GetBookmarksForUser.REQUEST:
       return {
         ...state,
-        bookmarksForUser: [],
+        bookmarksForUser: {
+          ...initialBookmarkState
+        }
       };
     case GetBookmarksForUser.SUCCESS:
       return {
@@ -108,10 +121,13 @@ export default function reducer(state: BookmarkReducerState = initialState, acti
         bookmarksForUser: (<GetBookmarksForUserResponse>action).payload.bookmarks,
       };
     case RemoveBookmark.SUCCESS:
-      const { resourceKey } = (<RemoveBookmarkResponse>action).payload;
+      const { resourceKey, resourceType } = (<RemoveBookmarkResponse>action).payload;
       return {
         ...state,
-        myBookmarks: state.myBookmarks.filter((bookmark) => bookmark.key !== resourceKey)
+        myBookmarks: {
+          ...state.myBookmarks,
+          [resourceType]: state.myBookmarks[resourceType].filter((bookmark) => bookmark.key !== resourceKey)
+        }
       };
     case AddBookmark.FAILURE:
     case GetBookmarks.FAILURE:

--- a/amundsen_application/static/js/ducks/bookmark/reducer.ts
+++ b/amundsen_application/static/js/ducks/bookmark/reducer.ts
@@ -1,4 +1,4 @@
-import { Bookmark, ResourceType } from 'interfaces';
+import { Bookmark, ResourceType, ResourceDict } from 'interfaces';
 
 import {
   AddBookmark,
@@ -28,7 +28,7 @@ export function addBookmark(resourceKey: string, resourceType: ResourceType): Ad
 export function addBookmarkFailure(): AddBookmarkResponse {
   return { type: AddBookmark.FAILURE };
 }
-export function addBookmarkSuccess(bookmarks: BookmarkState): AddBookmarkResponse {
+export function addBookmarkSuccess(bookmarks: ResourceDict<Bookmark[]>): AddBookmarkResponse {
   return { type: AddBookmark.SUCCESS, payload: { bookmarks } };
 }
 
@@ -56,7 +56,7 @@ export function getBookmarks(): GetBookmarksRequest {
 export function getBookmarksFailure(): GetBookmarksResponse {
   return { type: GetBookmarks.FAILURE };
 }
-export function getBookmarksSuccess(bookmarks: BookmarkState): GetBookmarksResponse {
+export function getBookmarksSuccess(bookmarks: ResourceDict<Bookmark[]>): GetBookmarksResponse {
   return { type: GetBookmarks.SUCCESS, payload: { bookmarks } };
 }
 
@@ -71,19 +71,15 @@ export function getBookmarksForUser(userId: string): GetBookmarksForUserRequest 
 export function getBookmarksForUserFailure(): GetBookmarksForUserResponse {
   return { type: GetBookmarksForUser.FAILURE };
 }
-export function getBookmarksForUserSuccess(bookmarks: BookmarkState): GetBookmarksForUserResponse {
+export function getBookmarksForUserSuccess(bookmarks: ResourceDict<Bookmark[]>): GetBookmarksForUserResponse {
   return { type: GetBookmarksForUser.SUCCESS, payload: { bookmarks } };
 }
 
 /* REDUCER */
-export interface BookmarkState {
-  [ResourceType.table]: Bookmark[],
-  [ResourceType.dashboard]: Bookmark[],
-}
 export interface BookmarkReducerState {
-  myBookmarks: BookmarkState;
+  myBookmarks: ResourceDict<Bookmark[]>;
   myBookmarksIsLoaded: boolean;
-  bookmarksForUser: BookmarkState;
+  bookmarksForUser: ResourceDict<Bookmark[]>;
 }
 export const initialBookmarkState = {
   [ResourceType.table]: [],

--- a/amundsen_application/static/js/ducks/bookmark/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/bookmark/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { expectSaga, testSaga } from 'redux-saga-test-plan';
+/*import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { throwError } from 'redux-saga-test-plan/providers';
 
@@ -348,4 +348,4 @@ describe('bookmark ducks', () => {
       });
     });
   });
-});
+});*/

--- a/amundsen_application/static/js/ducks/bookmark/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/bookmark/tests/index.spec.ts
@@ -1,8 +1,8 @@
-/*import { expectSaga, testSaga } from 'redux-saga-test-plan';
+import { expectSaga, testSaga } from 'redux-saga-test-plan';
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { throwError } from 'redux-saga-test-plan/providers';
 
-import { Bookmark, ResourceType } from 'interfaces';
+import { Bookmark, ResourceType, ResourceDict } from 'interfaces';
 
 import * as API from '../api/v0';
 import reducer, {
@@ -10,7 +10,7 @@ import reducer, {
   getBookmarks, getBookmarksFailure, getBookmarksSuccess,
   getBookmarksForUser, getBookmarksForUserFailure, getBookmarksForUserSuccess,
   removeBookmark, removeBookmarkFailure, removeBookmarkSuccess,
-  initialState, BookmarkReducerState
+  initialState, initialBookmarkState, BookmarkReducerState
 } from '../reducer';
 import {
   addBookmarkWatcher, addBookmarkWorker,
@@ -26,7 +26,7 @@ import {
 } from '../types';
 
 describe('bookmark ducks', () => {
-  let bookmarks: Bookmark[];
+  let bookmarks: ResourceDict<Bookmark[]>;
   let testResourceKey: string;
   let testResourceType: ResourceType;
   let testUserId: string;
@@ -34,17 +34,19 @@ describe('bookmark ducks', () => {
     testResourceKey = 'key';
     testResourceType = ResourceType.table;
     testUserId = 'userId';
-    bookmarks = [
-      {
-        key: testResourceKey,
-        type: testResourceType,
-        cluster: 'cluster',
-        database: 'database',
-        description: 'description',
-        name: 'name',
-        schema: 'schema',
-      },
-    ];
+    bookmarks = {
+      [testResourceType]: [
+        {
+          key: testResourceKey,
+          type: testResourceType,
+          cluster: 'cluster',
+          database: 'database',
+          description: 'description',
+          name: 'name',
+          schema: 'schema',
+        },
+      ]
+    }
   });
 
   describe('actions', () => {
@@ -77,7 +79,6 @@ describe('bookmark ducks', () => {
       const action = getBookmarksFailure();
       const { payload } = action;
       expect(action.type).toBe(GetBookmarks.FAILURE);
-      expect(payload.bookmarks).toEqual([]);
     });
 
     it('getBookmarksSuccess - returns the action to process success', () => {
@@ -98,7 +99,6 @@ describe('bookmark ducks', () => {
       const action = getBookmarksForUserFailure();
       const { payload } = action;
       expect(action.type).toBe(GetBookmarksForUser.FAILURE);
-      expect(payload.bookmarks).toEqual([]);
     });
 
     it('getBookmarksForUserSuccess - returns the action to process success', () => {
@@ -132,28 +132,30 @@ describe('bookmark ducks', () => {
 
   describe('reducer', () => {
     let testState: BookmarkReducerState;
-    let bookmarkList: Bookmark[];
+    let bookmarkList: ResourceDict<Bookmark[]>;
     beforeEach(() => {
-      bookmarkList = [
-        {
-          key: 'bookmarked_key_0',
-          type: ResourceType.table,
-          cluster: 'cluster',
-          database: 'database',
-          description: 'description',
-          name: 'name',
-          schema: 'schema',
-        },
-        {
-          key: 'bookmarked_key_1',
-          type: ResourceType.table,
-          cluster: 'cluster',
-          database: 'database',
-          description: 'description',
-          name: 'name',
-          schema: 'schema',
-        },
-      ];
+      bookmarkList = {
+        [ResourceType.table]: [
+          {
+            key: 'bookmarked_key_0',
+            type: ResourceType.table,
+            cluster: 'cluster',
+            database: 'database',
+            description: 'description',
+            name: 'name',
+            schema: 'schema',
+          },
+          {
+            key: 'bookmarked_key_1',
+            type: ResourceType.table,
+            cluster: 'cluster',
+            database: 'database',
+            description: 'description',
+            name: 'name',
+            schema: 'schema',
+          },
+        ]
+      };
       testState = {
         myBookmarks: bookmarkList,
         myBookmarksIsLoaded: false,
@@ -172,18 +174,20 @@ describe('bookmark ducks', () => {
       const bookmarkKey = 'bookmarked_key_1';
       const action = { type: RemoveBookmark.SUCCESS, payload: { resourceType: ResourceType.table, resourceKey: bookmarkKey }};
       const newState = reducer(testState, action);
-      expect(newState.myBookmarks.find((bookmark) => bookmark.key === bookmarkKey)).toEqual(undefined);
+      expect(newState.myBookmarks[ResourceType.table].find((bookmark) => bookmark.key === bookmarkKey)).toEqual(undefined);
       expect(newState).toEqual({
         ...testState,
-        myBookmarks: [{
-          key: 'bookmarked_key_0',
-          type: ResourceType.table,
-          cluster: 'cluster',
-          database: 'database',
-          description: 'description',
-          name: 'name',
-          schema: 'schema',
-        }],
+        myBookmarks: {
+          [ResourceType.table]: [{
+            key: 'bookmarked_key_0',
+            type: ResourceType.table,
+            cluster: 'cluster',
+            database: 'database',
+            description: 'description',
+            name: 'name',
+            schema: 'schema',
+          }]
+        }
       });
     });
 
@@ -213,7 +217,7 @@ describe('bookmark ducks', () => {
     it('should reset bookmarksForUser on GetBookmarksForUser.REQUEST', () => {
       expect(reducer(testState, { type: GetBookmarksForUser.REQUEST, payload: { userId: 'testUser' }})).toEqual({
         ...testState,
-        bookmarksForUser: [],
+        bookmarksForUser: initialBookmarkState,
       });
     });
   });
@@ -348,4 +352,4 @@ describe('bookmark ducks', () => {
       });
     });
   });
-});*/
+});

--- a/amundsen_application/static/js/ducks/bookmark/types.ts
+++ b/amundsen_application/static/js/ducks/bookmark/types.ts
@@ -1,4 +1,4 @@
-import { Bookmark } from 'interfaces';
+import { Bookmark, ResourceType } from 'interfaces';
 
 export enum AddBookmark {
   REQUEST = 'amundsen/bookmark/ADD_REQUEST',
@@ -9,13 +9,16 @@ export interface AddBookmarkRequest {
   type: AddBookmark.REQUEST;
   payload: {
     resourceKey: string;
-    resourceType: string;
+    resourceType: ResourceType;
   };
 }
 export interface AddBookmarkResponse {
   type: AddBookmark.SUCCESS | AddBookmark.FAILURE;
   payload?: {
-    bookmarks: Bookmark[];
+    bookmarks: {
+      [ResourceType.table]: Bookmark[];
+      [ResourceType.dashboard]: Bookmark[];
+    };
   }
 }
 
@@ -28,14 +31,14 @@ export interface RemoveBookmarkRequest {
   type: RemoveBookmark.REQUEST;
   payload: {
     resourceKey: string;
-    resourceType: string;
+    resourceType: ResourceType;
   };
 }
 export interface RemoveBookmarkResponse {
   type: RemoveBookmark.SUCCESS | RemoveBookmark.FAILURE;
   payload?: {
     resourceKey: string;
-    resourceType: string;
+    resourceType: ResourceType;
   };
 }
 
@@ -50,8 +53,11 @@ export interface GetBookmarksRequest {
 }
 export interface GetBookmarksResponse {
   type: GetBookmarks.SUCCESS | GetBookmarks.FAILURE;
-  payload: {
-    bookmarks: Bookmark[];
+  payload?: {
+    bookmarks: {
+      [ResourceType.table]: Bookmark[];
+      [ResourceType.dashboard]: Bookmark[];
+    };
   };
 }
 
@@ -69,7 +75,10 @@ export interface GetBookmarksForUserRequest {
 }
 export interface GetBookmarksForUserResponse {
   type: GetBookmarksForUser.SUCCESS | GetBookmarksForUser.FAILURE;
-  payload: {
-    bookmarks: Bookmark[];
+  payload?: {
+    bookmarks: {
+      [ResourceType.table]: Bookmark[];
+      [ResourceType.dashboard]: Bookmark[];
+    };
   };
 }

--- a/amundsen_application/static/js/ducks/bookmark/types.ts
+++ b/amundsen_application/static/js/ducks/bookmark/types.ts
@@ -1,4 +1,4 @@
-import { Bookmark, ResourceType } from 'interfaces';
+import { Bookmark, ResourceType, ResourceDict } from 'interfaces';
 
 export enum AddBookmark {
   REQUEST = 'amundsen/bookmark/ADD_REQUEST',
@@ -15,10 +15,7 @@ export interface AddBookmarkRequest {
 export interface AddBookmarkResponse {
   type: AddBookmark.SUCCESS | AddBookmark.FAILURE;
   payload?: {
-    bookmarks: {
-      [ResourceType.table]: Bookmark[];
-      [ResourceType.dashboard]: Bookmark[];
-    };
+    bookmarks: ResourceDict<Bookmark[]>;
   }
 }
 
@@ -54,10 +51,7 @@ export interface GetBookmarksRequest {
 export interface GetBookmarksResponse {
   type: GetBookmarks.SUCCESS | GetBookmarks.FAILURE;
   payload?: {
-    bookmarks: {
-      [ResourceType.table]: Bookmark[];
-      [ResourceType.dashboard]: Bookmark[];
-    };
+    bookmarks: ResourceDict<Bookmark[]>;
   };
 }
 
@@ -76,9 +70,6 @@ export interface GetBookmarksForUserRequest {
 export interface GetBookmarksForUserResponse {
   type: GetBookmarksForUser.SUCCESS | GetBookmarksForUser.FAILURE;
   payload?: {
-    bookmarks: {
-      [ResourceType.table]: Bookmark[];
-      [ResourceType.dashboard]: Bookmark[];
-    };
+    bookmarks: ResourceDict<Bookmark[]>;
   };
 }

--- a/amundsen_application/static/js/ducks/user/api/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/user/api/tests/index.spec.ts
@@ -2,7 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 
 import globalState from 'fixtures/globalState';
 
-import { LoggedInUser, PeopleUser, Resource } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceDict } from 'interfaces';
 
 import * as API from '../v0';
 
@@ -90,7 +90,7 @@ describe('getUserOwn', () => {
   let axiosMock;
   let mockGetResponse: AxiosResponse<API.UserOwnAPI>;
   let testId: string;
-  let testResources: Resource[];
+  let testResources;
   beforeAll(() => {
     testId = 'testId';
     testResources = globalState.user.profile.own;

--- a/amundsen_application/static/js/ducks/user/reducer.ts
+++ b/amundsen_application/static/js/ducks/user/reducer.ts
@@ -1,4 +1,4 @@
-import { LoggedInUser, PeopleUser, Resource } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceType } from 'interfaces';
 
 import {
   GetLoggedInUser, GetLoggedInUserRequest, GetLoggedInUserResponse,
@@ -34,7 +34,7 @@ export function getUserOwn(userId: string): GetUserOwnRequest {
 export function getUserOwnFailure(): GetUserOwnResponse {
   return { type: GetUserOwn.FAILURE };
 };
-export function getUserOwnSuccess(own: Resource[]): GetUserOwnResponse {
+export function getUserOwnSuccess(own: any): GetUserOwnResponse {
   return { type: GetUserOwn.SUCCESS, payload: { own } };
 };
 
@@ -52,7 +52,10 @@ export function getUserReadSuccess(read: Resource[]): GetUserReadResponse {
 export interface UserReducerState {
   loggedInUser: LoggedInUser;
   profile: {
-    own: Resource[],
+    own: {
+      [ResourceType.table]: Resource[];
+      [ResourceType.dashboard]: Resource[];
+    },
     read: Resource[],
     user: PeopleUser,
   };
@@ -74,10 +77,14 @@ export const defaultUser = {
   team_name: '',
   user_id: '',
 };
+const initialOwnState = {
+  [ResourceType.table]: [],
+  [ResourceType.dashboard]: [],
+};
 export const initialState: UserReducerState = {
   loggedInUser: defaultUser,
   profile: {
-    own: [],
+    own: initialOwnState,
     read: [],
     user: defaultUser,
   },
@@ -113,7 +120,9 @@ export default function reducer(state: UserReducerState = initialState, action):
         ...state,
         profile: {
           ...state.profile,
-          own: [],
+          own: {
+            ...initialOwnState
+          },
         }
       };
     case GetUserOwn.SUCCESS:

--- a/amundsen_application/static/js/ducks/user/reducer.ts
+++ b/amundsen_application/static/js/ducks/user/reducer.ts
@@ -1,4 +1,4 @@
-import { LoggedInUser, PeopleUser, Resource, ResourceType } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceType, ResourceDict } from 'interfaces';
 
 import {
   GetLoggedInUser, GetLoggedInUserRequest, GetLoggedInUserResponse,
@@ -34,7 +34,7 @@ export function getUserOwn(userId: string): GetUserOwnRequest {
 export function getUserOwnFailure(): GetUserOwnResponse {
   return { type: GetUserOwn.FAILURE };
 };
-export function getUserOwnSuccess(own: any): GetUserOwnResponse {
+export function getUserOwnSuccess(own: ResourceDict<Resource[]>): GetUserOwnResponse {
   return { type: GetUserOwn.SUCCESS, payload: { own } };
 };
 
@@ -52,10 +52,7 @@ export function getUserReadSuccess(read: Resource[]): GetUserReadResponse {
 export interface UserReducerState {
   loggedInUser: LoggedInUser;
   profile: {
-    own: {
-      [ResourceType.table]: Resource[];
-      [ResourceType.dashboard]: Resource[];
-    },
+    own: ResourceDict<Resource[]>,
     read: Resource[],
     user: PeopleUser,
   };
@@ -77,7 +74,7 @@ export const defaultUser = {
   team_name: '',
   user_id: '',
 };
-const initialOwnState = {
+export const initialOwnState = {
   [ResourceType.table]: [],
   [ResourceType.dashboard]: [],
 };

--- a/amundsen_application/static/js/ducks/user/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/user/tests/index.spec.ts
@@ -1,6 +1,6 @@
 import { testSaga } from 'redux-saga-test-plan';
 
-import { LoggedInUser, PeopleUser, Resource } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceDict } from 'interfaces';
 
 import globalState from 'fixtures/globalState';
 
@@ -10,7 +10,7 @@ import reducer, {
   getUser, getUserFailure, getUserSuccess,
   getUserOwn, getUserOwnFailure, getUserOwnSuccess,
   getUserRead, getUserReadFailure, getUserReadSuccess,
-  defaultUser, initialState, UserReducerState,
+  defaultUser, initialState, initialOwnState, UserReducerState,
 } from '../reducer';
 import {
   getLoggedInUserWorker, getLoggedInUserWatcher,
@@ -28,7 +28,7 @@ import {
 describe('user ducks', () => {
   let currentUser: LoggedInUser;
   let otherUser: {
-    own: Resource[],
+    own: ResourceDict<Resource[]>,
     read: Resource[],
     user: PeopleUser,
   };
@@ -170,7 +170,7 @@ describe('user ducks', () => {
         ...testState,
         profile: {
           ...testState.profile,
-          own: [],
+          own: initialOwnState,
         },
       });
     });
@@ -180,7 +180,7 @@ describe('user ducks', () => {
         ...testState,
         profile: {
           ...testState.profile,
-          own: [],
+          own: initialOwnState,
         },
       });
     });

--- a/amundsen_application/static/js/ducks/user/types.ts
+++ b/amundsen_application/static/js/ducks/user/types.ts
@@ -1,5 +1,5 @@
 
-import { LoggedInUser, PeopleUser, Resource, ResourceType } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceDict } from 'interfaces';
 
 export enum GetLoggedInUser {
   REQUEST = 'amundsen/current_user/GET_REQUEST',
@@ -50,10 +50,7 @@ export interface GetUserOwnRequest {
 export interface GetUserOwnResponse {
   type: GetUserOwn.SUCCESS | GetUserOwn.FAILURE;
   payload?: {
-    own: {
-      [ResourceType.table]: Resource[];
-      [ResourceType.dashboard]: Resource[];
-    };
+    own: ResourceDict<Resource[]>;
   };
 };
 

--- a/amundsen_application/static/js/ducks/user/types.ts
+++ b/amundsen_application/static/js/ducks/user/types.ts
@@ -1,5 +1,5 @@
 
-import { LoggedInUser, PeopleUser, Resource } from 'interfaces';
+import { LoggedInUser, PeopleUser, Resource, ResourceType } from 'interfaces';
 
 export enum GetLoggedInUser {
   REQUEST = 'amundsen/current_user/GET_REQUEST',
@@ -50,7 +50,10 @@ export interface GetUserOwnRequest {
 export interface GetUserOwnResponse {
   type: GetUserOwn.SUCCESS | GetUserOwn.FAILURE;
   payload?: {
-    own: Resource[];
+    own: {
+      [ResourceType.table]: Resource[];
+      [ResourceType.dashboard]: Resource[];
+    };
   };
 };
 

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -17,19 +17,39 @@ const globalState: GlobalState = {
       }],
   },
   bookmarks: {
-    myBookmarks: [
-      {
-        key: 'bookmarked_key',
-        type: ResourceType.table,
-        cluster: 'cluster',
-        database: 'database',
-        description: 'description',
-        name: 'name',
-        schema: 'schema',
-      },
-    ],
+    myBookmarks: {
+      [ResourceType.table]: [
+        {
+          key: 'bookmarked_key',
+          type: ResourceType.table,
+          cluster: 'cluster',
+          database: 'database',
+          description: 'description',
+          name: 'name',
+          schema: 'schema',
+        },
+      ],
+      [ResourceType.dashboard]: [
+        {
+          key: 'product_dashboard://cluster.group/name',
+          group_name: 'Amundsen Team',
+          group_url: 'product/group',
+          name: 'Amundsen Metrics Dashboard1',
+          product: 'mode',
+          type: ResourceType.dashboard,
+          description: 'I am a dashboard',
+          uri: 'product_dashboard://cluster.group/name',
+          url: 'product/name',
+          cluster: 'cluster',
+          last_successful_run_timestamp: 1585062593
+        },
+      ],
+    },
     myBookmarksIsLoaded: false,
-    bookmarksForUser: [],
+    bookmarksForUser: {
+      [ResourceType.table]: [],
+      [ResourceType.dashboard]: [],
+    },
   },
   // TODO - move dashboard to separate fixture
   dashboard: {

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -224,11 +224,14 @@ const globalState: GlobalState = {
       user_id: 'test0',
     },
     profile: {
-      own: [
-        { type: ResourceType.table },
-        { type: ResourceType.table },
-        { type: ResourceType.table },
-      ],
+      own: {
+        [ResourceType.table]: [
+          { type: ResourceType.table },
+          { type: ResourceType.table },
+          { type: ResourceType.table },
+        ],
+        [ResourceType.dashboard]: []
+      },
       read: [
         { type: ResourceType.table },
         { type: ResourceType.table },

--- a/amundsen_application/static/js/interfaces/Resources.ts
+++ b/amundsen_application/static/js/interfaces/Resources.ts
@@ -24,6 +24,8 @@ export interface DashboardResource extends Resource  {
   product: string;
   uri: string;
   url: string;
+  // Bookmark logic is cleaner if all resources can settle on either "key" or "uri"
+  key?: string;
 }
 
 export interface TableResource extends Resource {
@@ -44,4 +46,4 @@ export interface UserResource extends Resource, PeopleUser {
 }
 
 // TODO - Consider just using the 'Resource' type instead
-export type Bookmark = TableResource & {};
+export type Bookmark = TableResource | DashboardResource;

--- a/amundsen_application/static/js/interfaces/Resources.ts
+++ b/amundsen_application/static/js/interfaces/Resources.ts
@@ -45,5 +45,10 @@ export interface UserResource extends Resource, PeopleUser {
   type: ResourceType.user;
 }
 
+export interface ResourceDict<T> {
+  [ResourceType.table]: T;
+  [ResourceType.dashboard]?: T;
+}
+
 // TODO - Consider just using the 'Resource' type instead
 export type Bookmark = TableResource | DashboardResource;

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -256,30 +256,34 @@ class MetadataTest(unittest.TestCase):
                     'name': 'table_name_1',
                     'description': 'description',
                 },
-            ]
+            ],
+            'dashboard': [],
         }
-        self.expected_parsed_user_resources = [
-            {
-                'cluster': 'cluster',
-                'database': 'database',
-                'description': 'description',
-                'last_updated_timestamp': None,
-                'name': 'table_name_0',
-                'schema': 'schema',
-                'type': 'table',
-                'key': 'database://cluster.schema/table_name_0',
-            },
-            {
-                'cluster': 'cluster',
-                'database': 'database',
-                'description': 'description',
-                'last_updated_timestamp': None,
-                'name': 'table_name_1',
-                'schema': 'schema',
-                'type': 'table',
-                'key': 'database://cluster.schema/table_name_1',
-            },
-        ]
+        self.expected_parsed_user_resources = {
+            'table': [
+                {
+                    'cluster': 'cluster',
+                    'database': 'database',
+                    'description': 'description',
+                    'last_updated_timestamp': None,
+                    'name': 'table_name_0',
+                    'schema': 'schema',
+                    'type': 'table',
+                    'key': 'database://cluster.schema/table_name_0',
+                },
+                {
+                    'cluster': 'cluster',
+                    'database': 'database',
+                    'description': 'description',
+                    'last_updated_timestamp': None,
+                    'name': 'table_name_1',
+                    'schema': 'schema',
+                    'type': 'table',
+                    'key': 'database://cluster.schema/table_name_1',
+                },
+            ],
+            'dashboard': [],
+        }
 
     @responses.activate
     def test_popular_tables_success(self) -> None:
@@ -639,7 +643,10 @@ class MetadataTest(unittest.TestCase):
         with local_app.test_client() as test:
             response = test.get('/api/metadata/v0/user/bookmark')
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
-            expected = {'bookmarks': [], 'msg': 'Encountered error: failed to get bookmark for user_id: test_user_id'}
+            expected = {
+                'bookmarks': {'table': [], 'dashboard': []},
+                'msg': 'Encountered error: failed to get bookmark for user_id: test_user_id',
+            }
             self.assertEqual(response.json, expected)
 
     @responses.activate
@@ -718,7 +725,7 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user/read', query_string=dict(user_id=test_user))
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('read'), self.expected_parsed_user_resources)
+            self.assertCountEqual(data.get('read'), self.expected_parsed_user_resources.get('table'))
 
     @responses.activate
     def test_get_user_own(self) -> None:
@@ -733,4 +740,4 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user/own', query_string=dict(user_id=test_user))
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('own'), self.expected_parsed_user_resources)
+            self.assertCountEqual(data.get('own'), self.expected_parsed_user_resources.get('table'))

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -740,4 +740,4 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user/own', query_string=dict(user_id=test_user))
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('own'), self.expected_parsed_user_resources.get('table'))
+            self.assertCountEqual(data.get('own'), self.expected_parsed_user_resources)

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -354,6 +354,7 @@ class SearchDashboard(unittest.TestCase):
                 'product': 'mode',
                 'type': 'dashboard',
                 'uri': 'product_dashboard://cluster.group/name',
+                'key': 'product_dashboard://cluster.group/name',
                 'url': 'product/name'
             },
             {
@@ -366,6 +367,7 @@ class SearchDashboard(unittest.TestCase):
                 'product': 'mode',
                 'type': 'dashboard',
                 'uri': 'product_dashboard://cluster.group/name2',
+                'key': 'product_dashboard://cluster.group/name2',
                 'url': 'product/name'
             },
         ]

--- a/tests/unit/utils/test_search_utils.py
+++ b/tests/unit/utils/test_search_utils.py
@@ -87,6 +87,7 @@ class SearchUtilsTest(unittest.TestCase):
             'group_name': 'Amundsen Team',
             'group_url': 'product_dashboard://cluster.group',
             'name': 'Amundsen Metrics Dashboard',
+            'key': 'product_dashboard://cluster.group/name',
             'product': 'mode',
             'description': 'I am a dashboard',
             'uri': 'product_dashboard://cluster.group/name',


### PR DESCRIPTION
### Summary of Changes

This PR supports the following features:
1. Support the ability to bookmark a dashboard via appropriate changes to `BookmarkIcon` and bookmark api calls. Note the `resourceType` passed is no longer a string but now and actual `ResourceType` type.
2. Support the ability to show bookmarks and owned on the `ProfilePage`. The application state now stores `bookmarks` and `own` values as a `ResourceDict<Bookmark[]>` or `ResourceDict<Resource[]>` and the desired information is easily accessed through out the application by `ResourceType`.

### Tests

Tests added to cover changes.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
