### PR TITLE
Fixes typeahead result icons not showing

### DIFF
--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.spec.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { shallow } from 'enzyme';
 
-import ResultItem, { ResultItemProps } from '../';
+import ResultItem, { ResultItemProps } from '.';
 
 describe('ResultItem', () => {
   let props: ResultItemProps;
@@ -34,7 +34,7 @@ describe('ResultItem', () => {
     });
 
     it('renders icon with correct props', () => {
-      expect(link.find('img').props().className).toEqual(`result-icon ${props.iconClass}`);
+      expect(link.find('span').props().className).toEqual(`result-icon ${props.iconClass}`);
     });
 
     describe('renders result-info', () => {

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
@@ -15,7 +15,7 @@ const ResultItem: React.SFC<ResultItemProps> = ({ href, iconClass, id, onItemSel
   return (
     <li className="list-group-item">
       <Link id={id} className="result-item-link" onClick={onItemSelect} to={ href }>
-        <img className={`result-icon ${iconClass}`} />
+        <span className={`result-icon ${iconClass}`} />
 
         <div className="result-info my-auto">
           <div className="truncated">

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/styles.scss
@@ -71,7 +71,7 @@
           text-decoration: none;
 
           img.icon.icon-search,
-          img.icon.result-icon,
+          span.icon.result-icon,
           .sb-avatar {
             margin: auto 8px auto 0px;
           }


### PR DESCRIPTION
### Summary of Changes
Fixes icons on the typeahead suggested results not showing
Updates test and moves it out of the /test folder

### Tests
Updated tests


### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
