### PR TITLE
[AMD-1419] Added target property to image preview

### DIFF
--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -58,7 +58,7 @@ export class ImagePreview extends React.Component<ImagePreviewProps, ImagePrevie
         }
         {
           this.state.hasError &&
-          <Linkify className='body-placeholder'>{`${Constants.ERROR_MESSAGE} ${redirectUrl}`}</Linkify>
+          <Linkify className='body-placeholder' properties={{ target: '_blank' }}>{`${Constants.ERROR_MESSAGE} ${redirectUrl}`}</Linkify>
         }
       </div>
     );

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -58,7 +58,7 @@ export class ImagePreview extends React.Component<ImagePreviewProps, ImagePrevie
         }
         {
           this.state.hasError &&
-          <Linkify className='body-placeholder' properties={{ target: '_blank' }}>{`${Constants.ERROR_MESSAGE} ${redirectUrl}`}</Linkify>
+          <Linkify className='body-placeholder' properties={{ target: '_blank', rel:'noopener noreferrer' }}  >{`${Constants.ERROR_MESSAGE} ${redirectUrl}`}</Linkify>
         }
       </div>
     );


### PR DESCRIPTION
### Summary of Changes
When a dashboard detail page in Amundsen loads, it attempts to load an image preview of the dashboard from Mode, if it fails it gives a Mode link, with this change Mode link will open in new tab so that user will not loose context.

### Tests

No new tests were added or modified.

### Documentation
No change

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
