### PR TITLE
fix: Fix SearchPage min-height

### DIFF
--- a/amundsen_application/static/js/components/SearchPage/styles.scss
+++ b/amundsen_application/static/js/components/SearchPage/styles.scss
@@ -2,7 +2,7 @@
 
 .search-page {
   display: flex;
-  min-height: calc(100% - #{$nav-bar-height + $footer-height});
+  min-height: calc(100vh - #{$nav-bar-height + $footer-height});
 
   .list-group {
      margin-top: 0px;


### PR DESCRIPTION
### Summary of Changes

At some point, our styles for the height of the `SearchPage` stopped working as intended. The page was no longer taking up the full height unless there was content to fill it -- this could be observed on an empty `SearchPage` where `Dashboard` or `People` is selected as the resource.

I was unable to trace when this actually broke, but updated the css accordingly to fix the issue.

_Before_
![image](https://user-images.githubusercontent.com/1790900/82932067-b9a9f980-9f3c-11ea-9e56-d6bd6edb48f3.png)

_After_
![image](https://user-images.githubusercontent.com/1790900/82932111-c62e5200-9f3c-11ea-9a53-fcf403d13a36.png)


### Tests

N/A for this kind of fix

### Documentation

N/A for this kind of fix

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
