### PR TITLE
fix: null string passed as text to Flag component prevents page load

### DIFF
--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -16,6 +16,7 @@ export interface FlagProps {
 }
 
 export function convertText(str: string, caseType: string): string {
+  str = str || "";
   switch (caseType) {
     case CaseType.LOWER_CASE:
       return str.toLowerCase();

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -16,7 +16,7 @@ export interface FlagProps {
 }
 
 export function convertText(str: string, caseType: string): string {
-  str = str || "";
+  str = str || '';
   switch (caseType) {
     case CaseType.LOWER_CASE:
       return str.toLowerCase();

--- a/amundsen_application/static/js/components/common/Flag/tests/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Flag/tests/index.spec.tsx
@@ -51,5 +51,9 @@ describe('Flag', () => {
         it('returns text in defauilt case', () => {
             expect(convertText(text, 'not a valid options')).toEqual(text);
         });
+
+        it('returns empty strings for null values', () => {
+            expect(convertText(null, CaseType.SENTENCE_CASE)).toEqual('');
+        });
     });
 });


### PR DESCRIPTION
### Summary of Changes

Currently, if you pass a null value as the `text` property to a `Flag` component with any sort of capitalization rule (e.g., `CaseType.SENTENCE_CASE`), the attempt to call string methods on the null value results in errors that completely block page load. This change quietly coerces null values to empty strings in `convertText()` to avoid this issue.

I ran into this issue while trying to load a dashboard with a null value for `last_run_status`.

### Tests

Added unit test to `components/common/Flag/tests/index.spec.tsx`

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes, including screenshots of any UI changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [n/a] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
