### PR TITLE
fix: Miscellaneous UI Fixes

### DIFF
--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -99,13 +99,19 @@ $resource-header-height: 84px;
 
       .section-title {
         color: $text-tertiary;
-        margin: 40px 0 8px;
+        margin-bottom: 8px;
+      }
+
+      .editable-section,
+      .metadata-section {
+        margin-top: 40px;
+        min-height: 70px;
       }
 
       .editable-text {
         font-size: 16px;
 
-        .markdown-wrapper{
+        .markdown-wrapper {
           font-size: 16px;
         }
       }

--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -8,7 +8,7 @@ $resource-header-height: 84px;
     display: flex;
     height: $resource-header-height;
     border-bottom: 2px solid $divider;
-    padding: 16px 24px 0;
+    padding: 16px 24px;
 
 
     .icon-header {
@@ -20,11 +20,13 @@ $resource-header-height: 84px;
     .header-section {
       &.header-title {
         flex-grow: 1;
-        overflow: hidden;
 
         .header-title-text {
           display: inline-block;
           max-width: calc(100% - 100px);
+          // Better align the header-title-text
+          // (84px header height - 32px vertical padding - 2px border - 20px subtitle line-height) = 30px
+          line-height: 30px;
         }
       }
 

--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -106,6 +106,7 @@ $resource-header-height: 84px;
       .metadata-section {
         margin-top: 40px;
         min-height: 70px;
+        display: inline-table;
       }
 
       .editable-text {

--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -2,7 +2,7 @@
 $resource-header-height: 84px;
 
 .resource-detail-layout {
-  height: calc(100% - #{$nav-bar-height} - #{$footer-height});
+  height: calc(100vh - #{$nav-bar-height} - #{$footer-height});
 
   .resource-header {
     display: flex;

--- a/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/ImagePreview/index.tsx
@@ -33,7 +33,7 @@ const PreviewModal = ({ imageSrc, onClose }: PreviewModalProps) => {
   return (
     <Modal show={show} onHide={handleClose} scrollable="true" className="dashboard-preview-modal">
       <Modal.Header closeButton={true}>
-        <Modal.Title className="text-center">Constants.DASHBOARD_PREVIEW_MODAL_TITLE</Modal.Title>
+        <Modal.Title className="text-center">{Constants.DASHBOARD_PREVIEW_MODAL_TITLE}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <img

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -207,40 +207,48 @@ export class DashboardPage extends React.Component<DashboardPageProps, Dashboard
             </EditableSection>
             <section className="column-layout-2">
               <section className="left-panel">
-                <div className="section-title title-3">Owners</div>
-                <div>
-                  {
-                    dashboard.owners.length > 0 &&
-                    dashboard.owners.map(owner =>
-                      <Link
-                        key={owner.user_id}
-                        to={`/user/${owner.user_id}?source=${DASHBOARD_OWNER_SOURCE}`}>
-                        <AvatarLabel
-                          label={owner.display_name}/>
-                      </Link>
-                    )
-                  }
-                  {
-                    dashboard.owners.length === 0 &&
-                    <AvatarLabel
-                      avatarClass='gray-avatar'
-                      labelClass='text-placeholder'
-                      label={NO_OWNER_TEXT}
-                    />
-                  }
-                </div>
-                <div className="section-title title-3">Created</div>
-                <div className="body-2 text-primary">
-                  { formatDateTimeShort({ epochTimestamp: dashboard.created_timestamp}) }
-                </div>
-                <div className="section-title title-3">Last Updated</div>
-                <div className="body-2 text-primary">
-                  { formatDateTimeShort({ epochTimestamp: dashboard.updated_timestamp }) }
-                </div>
-                <div className="section-title title-3">Recent View Count</div>
-                <div className="body-2 text-primary">
-                  { dashboard.recent_view_count }
-                </div>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Owners</div>
+                  <div>
+                    {
+                      dashboard.owners.length > 0 &&
+                      dashboard.owners.map(owner =>
+                        <Link
+                          key={owner.user_id}
+                          to={`/user/${owner.user_id}?source=${DASHBOARD_OWNER_SOURCE}`}>
+                          <AvatarLabel
+                            label={owner.display_name}/>
+                        </Link>
+                      )
+                    }
+                    {
+                      dashboard.owners.length === 0 &&
+                      <AvatarLabel
+                        avatarClass='gray-avatar'
+                        labelClass='text-placeholder'
+                        label={NO_OWNER_TEXT}
+                      />
+                    }
+                  </div>
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Created</div>
+                  <div className="body-2 text-primary">
+                    { formatDateTimeShort({ epochTimestamp: dashboard.created_timestamp}) }
+                  </div>
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Last Updated</div>
+                  <div className="body-2 text-primary">
+                    { formatDateTimeShort({ epochTimestamp: dashboard.updated_timestamp }) }
+                  </div>
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Recent View Count</div>
+                  <div className="body-2 text-primary">
+                    { dashboard.recent_view_count }
+                  </div>
+                </section>
               </section>
               <section className="right-panel">
                 <EditableSection title="Tags">
@@ -249,23 +257,27 @@ export class DashboardPage extends React.Component<DashboardPageProps, Dashboard
                     uriKey={ this.props.dashboard.uri }
                   />
                 </EditableSection>
-                <div className="section-title title-3">Last Successful Run</div>
-                <div className="body-2 text-primary">
-                  { formatDateTimeShort({ epochTimestamp: dashboard.last_successful_run_timestamp }) }
-                </div>
-                <div className="section-title title-3">Last Run</div>
-                <div>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Last Successful Run</div>
                   <div className="body-2 text-primary">
-                    { formatDateTimeShort({ epochTimestamp: dashboard.last_run_timestamp }) }
+                    { formatDateTimeShort({ epochTimestamp: dashboard.last_successful_run_timestamp }) }
                   </div>
-                  <div className="last-run-state">
-                    <Flag
-                      caseType='sentenceCase'
-                      text={ dashboard.last_run_state }
-                      labelStyle={this.mapStatusToStyle(dashboard.last_run_state)}
-                    />
+                </section>
+                <section className="metadata-section">
+                  <div className="section-title title-3">Last Run</div>
+                  <div>
+                    <div className="body-2 text-primary">
+                      { formatDateTimeShort({ epochTimestamp: dashboard.last_run_timestamp }) }
+                    </div>
+                    <div className="last-run-state">
+                      <Flag
+                        caseType='sentenceCase'
+                        text={ dashboard.last_run_state }
+                        labelStyle={this.mapStatusToStyle(dashboard.last_run_state)}
+                      />
+                    </div>
                   </div>
-                </div>
+                </section>
               </section>
             </section>
             <ImagePreview uri={this.state.uri} redirectUrl={dashboard.url} />

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -155,36 +155,42 @@ class TableDetail extends React.Component<TableDetailProps & RouteComponentProps
           </header>
           <article className="column-layout-1">
             <section className="left-panel">
-              {}
               <EditableSection title="Description">
                 <TableDescEditableText
                   maxLength={ AppConfig.editableText.tableDescLength }
                   value={ data.description }
                   editable={ data.is_editable }
                 />
+                <span>
+                  { notificationsEnabled() && <RequestDescriptionText/> }
+                </span>
               </EditableSection>
-              <span>
-                { notificationsEnabled() && <RequestDescriptionText/> }
-              </span>
-              {issueTrackingEnabled() && <TableIssues tableKey={ this.key } tableName={ this.getDisplayName()}/>}
+              {
+                issueTrackingEnabled() &&
+                <section className="metadata-section">
+                  <TableIssues tableKey={ this.key } tableName={ this.getDisplayName()}/>
+                </section>
+              }
               <section className="column-layout-2">
                 <section className="left-panel">
                   {
                     !data.is_view &&
-                    <>
+                    <section className="metadata-section">
                       <div className="section-title title-3">Date Range</div>
                       <WatermarkLabel watermarks={ data.watermarks }/>
-                    </>
+                    </section>
                   }
                   {
                     !!data.last_updated_timestamp &&
-                    <>
+                    <section className="metadata-section">
                       <div className="section-title title-3">Last Updated</div>
                       <div className="body-2">{ formatDateTimeShort({ epochTimestamp: data.last_updated_timestamp }) }</div>
-                    </>
+                    </section>
                   }
-                  <div className="section-title title-3">Frequent Users</div>
-                  <FrequentUsers readers={ data.table_readers }/>
+                  <section className="metadata-section">
+                    <div className="section-title title-3">Frequent Users</div>
+                    <FrequentUsers readers={ data.table_readers }/>
+                  </section>
                 </section>
                 <section className="right-panel">
                   <EditableSection title="Tags">

--- a/amundsen_application/static/js/components/TableDetail/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/styles.scss
@@ -13,4 +13,13 @@
       margin: 10px 0 4px;
     }
   }
+
+  .header-links {
+    .avatar-label {
+      &:focus,
+      &:hover {
+        color: $link-hover-color;
+      }
+    }
+  }
 }

--- a/amundsen_application/static/js/components/TableDetail/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/styles.scss
@@ -1,8 +1,6 @@
 @import 'variables';
 
 .table-detail {
-  height: calc(100% - #{$nav-bar-height} - #{$footer-height});
-
   .column-layout-1 .left-panel {
     .programmatic-title {
       color: $text-primary;

--- a/amundsen_application/static/js/components/common/EditableSection/constants.ts
+++ b/amundsen_application/static/js/components/common/EditableSection/constants.ts
@@ -1,0 +1,1 @@
+export const EDIT_TEXT = 'Click to edit';

--- a/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
@@ -88,5 +88,10 @@ describe("EditableSection", () => {
         expect(wrapper.find(".edit-button").props().href).toBe(props.editUrl);
       });
     });
+
+    it("does not render button if readOnly=true and there is no external editUrl", () => {
+      const wrapper = setup({ readOnly: true }, <div/>).wrapper;
+      expect(wrapper.find(".edit-button").exists()).toBeFalsy();
+    });
   });
 });

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
+import * as Constants from './constants';
+
 import './styles.scss';
 
 export interface EditableSectionProps {
@@ -22,6 +24,10 @@ export interface EditableSectionChildProps {
 }
 
 export class EditableSection extends React.Component<EditableSectionProps, EditableSectionState> {
+  static defaultProps: Partial<EditableSectionProps> = {
+    editText: Constants.EDIT_TEXT,
+  };
+
   constructor(props) {
     super(props);
 
@@ -53,6 +59,10 @@ export class EditableSection extends React.Component<EditableSectionProps, Edita
   renderReadOnlyButton = (): React.ReactNode => {
     const { editText, editUrl } = this.props;
     const popoverHoverFocus = (<Popover id="popover-trigger-hover-focus">{ editText }</Popover>);
+
+    if (!editUrl) {
+      return null;
+    }
     return (
       <OverlayTrigger
        trigger={["hover", "focus"]}


### PR DESCRIPTION
### Summary of Changes
This PR make a series of UI and style fixes described below.  Each commit is scoped to a particular task for easier review.

#### 1. Fix Dashboard Preview Title
This fix is also included in https://github.com/lyft/amundsenfrontendlibrary/pull/467, but will just resolve on merge vs. reverting the commit.

#### 2. Improve Resource Header Vertical Spacing Balance
**Before:**
![image](https://user-images.githubusercontent.com/1790900/83300401-c46ac580-a1ac-11ea-8523-fdc06e4bac96.png)
**After:**
![image](https://user-images.githubusercontent.com/1790900/83300368-b74dd680-a1ac-11ea-893e-110b1acbb15c.png)

#### 3. Min-height Metadata Sections
Design proposed to make the metadata sections in the left panel have a min-height, which will currently be 70px. The reason for this is so that most pages becomes more aesthetically pleasing by having column items align vs. before where many cases would be just slightly off. The design sentiment is that either items will align or be very clearly not aligned. 

**Before:** (items slightly off)
    <img src='https://user-images.githubusercontent.com/1790900/83300808-8a4df380-a1ad-11ea-8e62-e83cb8210cbe.png' width='40%'/>

**After:**
    <img src='https://user-images.githubusercontent.com/1790900/83300895-a6ea2b80-a1ad-11ea-966b-90d0f011c1ac.png' width='40%' />

#### 4. Update EditableSection
A readOnly `EditableSection` was rendering the edit button and the empty popover when not given the optional `editText` or `editUrl`. This fix adds a default `editText` prompt, and also does not render the button if there is no `editUrl` provided -- since the button will have no effect in that case.
**Before:**
<img src='https://user-images.githubusercontent.com/1790900/83301523-ab631400-a1ae-11ea-9d4e-2e95f3572450.png' width='35%' />
**After:** (no button)
<img src='https://user-images.githubusercontent.com/1790900/83301554-b74ed600-a1ae-11ea-94ae-73722efa34dc.png' width='40%' />

#### 5. Fix Resource Detail Height
This was another area where we needed to switch to `100vh` when calculating the height.

#### 6. Hover Effects on Service Links
Updated the component style on hover.
_Example_:
<img src='https://user-images.githubusercontent.com/1790900/83301995-6be8f780-a1af-11ea-9618-197568ec1e11.png' width='50%' />


### Tests

Added a test to `EditableSection`.

### Documentation

N/A for UI fixes

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
