### PR TITLE
fix: Update some python assertions

### DIFF
--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -266,10 +266,10 @@ class MetadataTest(unittest.TestCase):
             'github_username': 'githubusername',
             'is_active': True,
             'last_name': 'Lastname',
-            'manager_email': 'manager@email.com',
+            'manager_email': None,
             'manager_fullname': 'Manager Fullname',
             'manager_id': 'managerid',
-            'profile_url': 'https://test-profile-url.com',
+            'profile_url': '',
             'role_name': 'SWE',
             'slack_id': 'slackuserid',
             'team_name': 'Amundsen',
@@ -832,7 +832,7 @@ class MetadataTest(unittest.TestCase):
             response = test.get('/api/metadata/v0/user', query_string=dict(user_id='testuser'))
             data = json.loads(response.data)
             self.assertEquals(response.status_code, HTTPStatus.OK)
-            self.assertCountEqual(data.get('user'), self.expected_parsed_user)
+            self.assertDictContainsSubset(self.expected_parsed_user, data.get('user'))
 
     @responses.activate
     def test_get_bookmark(self) -> None:

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -299,7 +299,7 @@ class SearchUser(unittest.TestCase):
 
             users = data.get('users')
             self.assertEqual(users.get('total_results'), self.mock_search_user_results.get('total_results'))
-            self.assertCountEqual(users.get('results'), self.expected_parsed_search_user_results)
+            self.assertDictContainsSubset(self.expected_parsed_search_user_results[0], users.get('results')[0])
 
     @responses.activate
     def test_search_user_fail_on_non_200_response(self) -> None:


### PR DESCRIPTION
### Summary of Changes

This PR updates some of the weaker assertions we are using in our python tests, where tests fail if there are changes in `amundsen-common` that add new parameters. This change should prevent tests from failing when the `User` model is in development.

There is more work to be done here in terms of making our tests verify specific values and applying these changes across all tests, however this PR aims to just unblock Travis failures on this repo right now. 

### Tests

See above.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
