### PR TITLE
feat: Mode dashboard preview ACL

### DIFF
--- a/amundsen_application/api/preview/dashboard/v0.py
+++ b/amundsen_application/api/preview/dashboard/v0.py
@@ -47,6 +47,9 @@ def get_preview_image(uri: str) -> Response:
     except FileNotFoundError as fne:
         LOGGER.exception('FileNotFoundError on get_preview_image')
         return make_response(jsonify({'msg': fne.args[0]}), HTTPStatus.NOT_FOUND)
+    except PermissionError as pe:
+        LOGGER.exception('PermissionError on get_preview_image')
+        return make_response(jsonify({'msg': pe.args[0]}), HTTPStatus.UNAUTHORIZED)
     except Exception as e:
         LOGGER.exception('Unexpected failure on get_preview_image')
         return make_response(jsonify({'msg': 'Encountered exception: ' + str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -87,7 +87,7 @@ class Config:
 
 
 class LocalConfig(Config):
-    DEBUG = True
+    DEBUG = False
     TESTING = False
     LOG_LEVEL = 'DEBUG'
 

--- a/amundsen_application/config.py
+++ b/amundsen_application/config.py
@@ -81,10 +81,13 @@ class Config:
     CREDENTIALS_MODE_ADMIN_PASSWORD = os.getenv('CREDENTIALS_MODE_ADMIN_PASSWORD', None)
     MODE_ORGANIZATION = None
     MODE_REPORT_URL_TEMPLATE = None
+    # Add Preview class name below to enable ACL, assuming it is supported by the Preview class
+    # e.g: ACL_ENABLED_DASHBOARD_PREVIEW = {'ModePreview'}
+    ACL_ENABLED_DASHBOARD_PREVIEW = set()  # type: Set[Optional[str]]
 
 
 class LocalConfig(Config):
-    DEBUG = False
+    DEBUG = True
     TESTING = False
     LOG_LEVEL = 'DEBUG'
 

--- a/amundsen_application/dashboard_preview/mode_preview.py
+++ b/amundsen_application/dashboard_preview/mode_preview.py
@@ -6,7 +6,10 @@ from flask import has_app_context, current_app as app
 from requests.auth import HTTPBasicAuth
 from retrying import retry
 
+from amundsen_application.api.metadata.v0 import USER_ENDPOINT
+from amundsen_application.api.utils.request_utils import request_metadata
 from amundsen_application.base.base_preview import BasePreview
+from amundsen_application.models.user import load_user
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_REPORT_URL_TEMPLATE = 'https://app.mode.com/api/{organization}/reports/{dashboard_id}'
@@ -16,6 +19,10 @@ def _validate_not_none(var: Any, var_name: str) -> Any:
     if not var:
         raise ValueError('{} is missing'.format(var_name))
     return var
+
+
+def _retry_on_retriable_error(exception: Exception) -> bool:
+    return not isinstance(exception, PermissionError)
 
 
 class ModePreview(BasePreview):
@@ -40,13 +47,26 @@ class ModePreview(BasePreview):
         if has_app_context() and app.config['MODE_REPORT_URL_TEMPLATE'] is not None:
             self._report_url_template = app.config['MODE_REPORT_URL_TEMPLATE']
 
-    @retry(stop_max_attempt_number=3, wait_random_min=500, wait_random_max=1000)
+        self._is_auth_enabled = False
+        if has_app_context() and app.config['ACL_ENABLED_DASHBOARD_PREVIEW']:
+            if not app.config['AUTH_USER_METHOD']:
+                raise Exception('AUTH_USER_METHOD must be configured to enable ACL_ENABLED_DASHBOARD_PREVIEW')
+            self._is_auth_enabled = self.__class__.__name__ in app.config['ACL_ENABLED_DASHBOARD_PREVIEW']
+            self._auth_user_method = app.config['AUTH_USER_METHOD']
+
+    @retry(stop_max_attempt_number=3, wait_random_min=500, wait_random_max=1000,
+           retry_on_exception=_retry_on_retriable_error)
     def get_preview_image(self, *, uri: str) -> bytes:
         """
         Retrieves short lived URL that provides Mode report preview, downloads it and returns it's bytes
         :param uri:
         :return: image bytes
+        :raise: PermissionError when user is not allowed to access the dashboard
         """
+
+        if self._is_auth_enabled:
+            self._authorize_access(user_email=self._auth_user_method(app).email)
+
         url = self._get_preview_image_url(uri=uri)
         r = requests.get(url, allow_redirects=True)
         r.raise_for_status()
@@ -74,3 +94,24 @@ class ModePreview(BasePreview):
             raise FileNotFoundError('No preview image available on {}'.format(uri))
 
         return image_url
+
+    def _authorize_access(self, user_email: str) -> None:
+        """
+        Get Mode user ID via metadata service. Note that metadata service needs to be at least v2.5.2 and
+        Databuilder should also have ingested Mode user.
+        https://github.com/lyft/amundsendatabuilder#modedashboarduserextractor
+
+        :param user_email:
+        :return:
+        :raise: PermissionError when user is not allowed to access the dashboard
+        """
+
+        metadata_svc_url = '{0}{1}/{2}'.format(app.config['METADATASERVICE_BASE'], USER_ENDPOINT, user_email)
+        response = request_metadata(url=metadata_svc_url)
+        response.raise_for_status()
+
+        user = load_user(response.json())
+        if user.is_active and user.other_key_values and user.other_key_values.get('mode_user_id'):
+            return
+
+        raise PermissionError('User {} is not authorized to preview Mode Dashboard'.format(user_email))

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ responses==0.9.0
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
-amundsen-common>=0.3.1,<1.0
+amundsen-common>=0.3.5,<1.0
 
 # Library for rest endpoints with Flask
 # Upstream url: https://github.com/flask-restful/flask-restful

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-__version__ = '2.3.0rc0'
+__version__ = '2.3.0'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-__version__ = '2.3.0'
+__version__ = '2.2.0'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'r
 with open(requirements_path) as requirements_file:
     requirements = requirements_file.readlines()
 
-__version__ = '2.2.0'
+__version__ = '2.3.0rc0'
 
 
 setup(

--- a/tests/unit/dashboard_preview/test_mode_preview.py
+++ b/tests/unit/dashboard_preview/test_mode_preview.py
@@ -4,8 +4,11 @@ from unittest.mock import patch
 
 import requests
 from requests.auth import HTTPBasicAuth
+from unittest.mock import MagicMock
 
+from amundsen_application import create_app
 from amundsen_application.dashboard_preview.mode_preview import ModePreview, DEFAULT_REPORT_URL_TEMPLATE
+from amundsen_application.api.utils import request_utils
 
 ACCESS_TOKEN = 'token'
 PASSWORD = 'password'
@@ -13,6 +16,15 @@ ORGANIZATION = 'foo'
 
 
 class TestModePreview(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.app = create_app(config_module_class='amundsen_application.config.LocalConfig')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self) -> None:
+        self.app_context.pop()
+
 
     def test_get_preview_image(self) -> None:
         with patch.object(ModePreview, '_get_preview_image_url') as mock_get_preview_image_url,\
@@ -56,3 +68,138 @@ class TestModePreview(unittest.TestCase):
             preview = ModePreview(access_token='token', password='password', organization='foo')
             mode_dashboard_uri = 'mode_dashboard://gold.dg/d_id'
             self.assertRaises(FileNotFoundError, preview._get_preview_image_url, uri=mode_dashboard_uri)
+
+    def test_auth_disabled(self) -> None:
+        preview = ModePreview(access_token='token', password='password', organization='foo')
+        self.assertFalse(preview._is_auth_enabled)
+
+    def test_auth_disabled_2(self) -> None:
+        self.app.config['ACL_ENABLED_DASHBOARD_PREVIEW'] = {'FooPreview'}
+        self.app.config['AUTH_USER_METHOD'] = MagicMock()
+
+        preview = ModePreview(access_token='token', password='password', organization='foo')
+        self.assertFalse(preview._is_auth_enabled)
+
+    def test_auth_enabled(self) -> None:
+        self.app.config['ACL_ENABLED_DASHBOARD_PREVIEW'] = {'ModePreview'}
+        self.app.config['AUTH_USER_METHOD'] = MagicMock()
+
+        preview = ModePreview(access_token='token', password='password', organization='foo')
+        self.assertTrue(preview._is_auth_enabled)
+
+
+    def test_authorization(self) -> None:
+        self.app.config['ACL_ENABLED_DASHBOARD_PREVIEW'] = {'ModePreview'}
+        self.app.config['AUTH_USER_METHOD'] = MagicMock()
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'True',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+                'other_key_values': {
+                    'mode_user_id': 'foo_mode_user_id'
+                }
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            preview._authorize_access(user_email='test_email')
+
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'False',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+                'other_key_values': {
+                    'mode_user_id': 'foo_mode_user_id'
+                }
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            self.assertRaises(PermissionError, preview._authorize_access, user_email='test_email')
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'True',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+                'other_key_values': {}
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            self.assertRaises(PermissionError, preview._authorize_access, user_email='test_email')
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'True',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+                'other_key_values': {
+                    'foo': 'bar'
+                }
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            self.assertRaises(PermissionError, preview._authorize_access, user_email='test_email')
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'True',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+                'other_key_values': None
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            self.assertRaises(PermissionError, preview._authorize_access, user_email='test_email')
+
+        with patch('amundsen_application.dashboard_preview.mode_preview.request_metadata') as mock_request_metadata:
+            mock_request_metadata.return_value.json.return_value = {
+                'employee_type': 'teamMember',
+                'full_name': 'test_full_name',
+                'is_active': 'True',
+                'github_username': 'test-github',
+                'slack_id': 'test_id',
+                'last_name': 'test_last_name',
+                'first_name': 'test_first_name',
+                'team_name': 'test_team',
+                'email': 'test_email',
+            }
+
+            preview = ModePreview(access_token='token', password='password', organization='foo')
+            self.assertRaises(PermissionError, preview._authorize_access, user_email='test_email')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes

Added `access control` on Mode dashboard preview.

- Calls `metadata service` is verify if user is `is_active` and has `mode_user_id`. Because, all Mode dashboard is in shared space, this two conditions are enough to validate the access.
- If user is not registered in `Mode` (does not have permission to view the report), it returns `401` Unauthorized.

### Tests

Unit tests updated.
Integration test done.

### Documentation

docstring

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
