### PR TITLE
fix: Properly handle readOnly in OwnerEditor component

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+
+import { shallow } from 'enzyme';
+
+import globalState from 'fixtures/globalState';
+import AvatarLabel from 'components/common/AvatarLabel';
+
+import {
+  OwnerEditor,
+  OwnerEditorProps,
+  mapStateToProps,
+  mapDispatchToProps,
+} from '.';
+
+describe('OwnerEditor', () => {
+  const setup = (propOverrides?: Partial<OwnerEditorProps>) => {
+    const props: OwnerEditorProps = {
+      errorText: null,
+      isLoading: false,
+      itemProps: {},
+      isEditing: null,
+      setEditMode: jest.fn(),
+      onUpdateList: jest.fn(),
+      readOnly: null,
+      ...propOverrides,
+    };
+    const wrapper = shallow<OwnerEditor>(<OwnerEditor {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
+    it('renders text if no owners', () => {
+      const { wrapper } = setup({ itemProps: {} });
+      expect(wrapper.find('.owner-editor-component').text()).toContain(
+        'No owners exist'
+      );
+    });
+
+    it('does not render Add Owner button if component is readOnly', () => {
+      const { wrapper } = setup({ itemProps: {}, readOnly: true });
+      expect(wrapper.find('.owner-editor-component').text()).toEqual(
+        'No owners exist<Modal />'
+      );
+    });
+
+    it('renders owners if they exist', () => {
+      const { wrapper } = setup({
+        itemProps: { owner1: {} },
+      });
+      expect(
+        wrapper.find('.owner-editor-component').find(AvatarLabel).exists()
+      ).toBe(true);
+    });
+  });
+
+  describe('mapDispatchToProps', () => {
+    let dispatch;
+    let props;
+
+    beforeAll(() => {
+      dispatch = jest.fn(() => Promise.resolve());
+      props = mapDispatchToProps(dispatch);
+    });
+
+    it('sets onUpdateList on the props', () => {
+      expect(props.onUpdateList).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    let result;
+    const ownProps = { readOnly: true };
+    beforeAll(() => {
+      result = mapStateToProps(globalState, ownProps);
+    });
+
+    it('sets isLoading on the props', () => {
+      expect(result.isLoading).toEqual(
+        globalState.tableMetadata.tableOwners.isLoading
+      );
+    });
+
+    it('sets readOnly on the props', () => {
+      expect(result.readOnly).toEqual(ownProps.readOnly);
+    });
+  });
+});

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -41,7 +41,7 @@ export interface StateFromProps {
   itemProps: { [id: string]: OwnerAvatarLabelProps };
 }
 
-type OwnerEditorProps = ComponentProps &
+export type OwnerEditorProps = ComponentProps &
   DispatchFromProps &
   StateFromProps &
   EditableSectionChildProps;
@@ -219,8 +219,8 @@ export class OwnerEditor extends React.Component<
       );
     }
 
-    if (this.state.itemProps.size === 0) {
-      content = <label className="status-message">No entries exist</label>;
+    if (Object.keys(this.state.itemProps).length === 0) {
+      content = <label className="body-3">No owners exist</label>;
     } else {
       content = (
         <ul className="component-list">
@@ -306,7 +306,10 @@ export class OwnerEditor extends React.Component<
   }
 }
 
-export const mapStateToProps = (state: GlobalState) => {
+export const mapStateToProps = (
+  state: GlobalState,
+  ownProps: ComponentProps & EditableSectionChildProps
+) => {
   const ownerObj = state.tableMetadata.tableOwners.owners;
   const items = Object.keys(ownerObj).reduce((obj, ownerId) => {
     const { profile_url, user_id, display_name } = ownerObj[ownerId];
@@ -327,6 +330,7 @@ export const mapStateToProps = (state: GlobalState) => {
   return {
     isLoading: state.tableMetadata.tableOwners.isLoading,
     itemProps: items,
+    readOnly: ownProps.readOnly,
   };
 };
 

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -21,6 +21,7 @@ interface EditableSectionState {
 export interface EditableSectionChildProps {
   isEditing?: boolean;
   setEditMode?: (isEditing: boolean) => void;
+  readOnly?: boolean;
 }
 
 export class EditableSection extends React.Component<
@@ -75,6 +76,10 @@ export class EditableSection extends React.Component<
 
   renderReadOnlyButton = (): React.ReactNode => {
     const { editText, editUrl } = this.props;
+    if (!editUrl) {
+      return;
+    }
+
     const popoverHoverFocus = (
       <Popover id="popover-trigger-hover-focus">{editText}</Popover>
     );
@@ -103,18 +108,20 @@ export class EditableSection extends React.Component<
 
   render() {
     const { title, readOnly = false } = this.props;
-    const childrenWithProps = !readOnly
-      ? React.Children.map(this.props.children, (child) => {
-          if (!React.isValidElement(child)) {
-            return child;
-          }
+    const childrenWithProps = React.Children.map(
+      this.props.children,
+      (child) => {
+        if (!React.isValidElement(child)) {
+          return child;
+        }
 
-          return React.cloneElement(child, {
-            isEditing: this.state.isEditing,
-            setEditMode: this.setEditMode,
-          });
-        })
-      : this.props.children;
+        return React.cloneElement(child, {
+          isEditing: this.state.isEditing,
+          setEditMode: this.setEditMode,
+          readOnly,
+        });
+      }
+    );
 
     return (
       <section className="editable-section">


### PR DESCRIPTION
### Summary of Changes

This PR deals with a few things related to `<OwnerEditor />`:
1. We were checking for `<object>.size` rather than `Object.keys(<object>).length` and therefore, the message about no entities existing was never going to show up.
2. I updated that message to say "No owners exist" instead, and removed the status-message class, since we don't need the "No owners exist" message to be bright red
3. When there were no owners, we were still displaying the "Add owner" button, which is confusing and I don't think intended. I updated the EditableSection component to properly pass the readOnly prop to its children so that the children can do the right thing
4. In the editableSection component, if you say the child is readOnly = true, but you don't pass in any editUrl or helper text, the user still sees the edit button. This is confusing and I don't think is the expected functionality. I've hidden that edit button when you don't pass in the extra props.

Here is a screenshot of the readOnly = true, no owners case:
![Screen Shot 2020-06-17 at 3 06 05 PM](https://user-images.githubusercontent.com/11583233/84960678-284f2280-b0b7-11ea-9492-8de5fb6a9f76.png)


### Tests

It does not look like there were tests for the OwnerEditor component, so I added some that are related to the changes I made

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
