### PR TITLE
fix: Update user icon on ProfilePage

### DIFF
--- a/amundsen_application/static/css/_icons.scss
+++ b/amundsen_application/static/css/_icons.scss
@@ -183,6 +183,11 @@ img.icon {
     mask-image: url('/static/images/icons/Up.svg');
   }
 
+  &.icon-user {
+    -webkit-mask-image: url('/static/images/icons/users.svg');
+    mask-image: url('/static/images/icons/users.svg');
+  }
+
   &.icon-more {
     -webkit-mask-image: url('/static/images/icons/More.svg');
     mask-image: url('/static/images/icons/More.svg');

--- a/amundsen_application/static/js/components/ProfilePage/index.tsx
+++ b/amundsen_application/static/js/components/ProfilePage/index.tsx
@@ -269,7 +269,7 @@ export class ProfilePage extends React.Component<
           target="_blank"
           rel="noreferrer"
         >
-          <span className="icon icon-dark icon-users" />
+          <img className="icon icon-dark icon-user" alt="" />
           <span className="profile-link-label body-2">{PROFILE_TEXT}</span>
         </a>
       );


### PR DESCRIPTION
### Summary of Changes

Recent style changes caused a UI regression where the hover state over the user icon on the ProfilePage was not correct, showing an indigo background.
**Before**
![image](https://user-images.githubusercontent.com/1790900/85341493-28776580-b49d-11ea-92c0-3b738257427d.png)

To fix this issue I reverted to using the previous mask image styling for this use case.
**After**
![image](https://user-images.githubusercontent.com/1790900/85341774-d71ba600-b49d-11ea-848a-e857b074b401.png)


### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
