### PR TITLE
fix: Separate related dashboards component & request

### DIFF
--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -674,7 +674,7 @@ def _get_related_dashboards_metadata(*, url: str) -> Dict[str, Any]:
     results_dict['status_code'] = status_code
 
     if status_code != HTTPStatus.OK:
-        message = response.raise_for_status()
+        message = f'Encountered {status_code} Error: Related dashboard metadata request failed'
         results_dict['msg'] = message
         logging.error(message)
         return results_dict

--- a/amundsen_application/api/metadata/v0.py
+++ b/amundsen_application/api/metadata/v0.py
@@ -656,7 +656,7 @@ def get_related_dashboard_metadata(table_key: str) -> Response:
 def _get_related_dashboards_metadata(*, url: str) -> Dict[str, Any]:
 
     results_dict = {
-        'dashboards': {},
+        'dashboards': [],
         'msg': '',
     }
 
@@ -674,7 +674,7 @@ def _get_related_dashboards_metadata(*, url: str) -> Dict[str, Any]:
     results_dict['status_code'] = status_code
 
     if status_code != HTTPStatus.OK:
-        message = 'Encountered error: Related Dashboard Metadata request failed'
+        message = response.raise_for_status()
         results_dict['msg'] = message
         logging.error(message)
         return results_dict

--- a/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.spec.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+
+import { shallow } from 'enzyme';
+
+import ResourceList from 'components/common/ResourceList';
+import ShimmeringResourceLoader from 'components/common/ShimmeringResourceLoader';
+
+import { dashboardSummary } from 'fixtures/metadata/dashboard';
+import globalState from 'fixtures/globalState';
+
+import {
+  TableDashboardResourceList,
+  TableDashboardResourceListProps,
+  mapStateToProps,
+} from '.';
+
+const setup = (propOverrides?: Partial<TableDashboardResourceListProps>) => {
+  const props = {
+    itemsPerPage: 10,
+    source: 'test',
+    dashboards: [],
+    isLoading: false,
+    errorText: 'test',
+    ...propOverrides,
+  };
+  const wrapper = shallow<TableDashboardResourceList>(
+    <TableDashboardResourceList {...props} />
+  );
+
+  return { props, wrapper };
+};
+
+describe('TableDashboardResourceList', () => {
+  describe('render', () => {
+    it('should render without problems', () => {
+      expect(() => {
+        setup();
+      }).not.toThrow();
+    });
+
+    it('should render the resource loader', () => {
+      const { props, wrapper } = setup({ isLoading: true });
+      const element = wrapper.find(ShimmeringResourceLoader);
+
+      expect(element.length).toEqual(1);
+      expect(element.props().numItems).toBe(props.itemsPerPage);
+    });
+
+    it('should render the resource list', () => {
+      const { props, wrapper } = setup();
+      const element = wrapper.find(ResourceList);
+
+      expect(element.length).toEqual(1);
+      expect(element.props().allItems).toBe(props.dashboards);
+      expect(element.props().emptyText).toBe(props.errorText);
+      expect(element.props().itemsPerPage).toBe(props.itemsPerPage);
+      expect(element.props().source).toBe(props.source);
+    });
+  });
+});
+
+describe('mapStateToProps', () => {
+  describe('when dashboards do not exist on tableMetadata state', () => {
+    let result;
+    beforeAll(() => {
+      result = mapStateToProps(globalState);
+    });
+
+    it('sets dashboards to default', () => {
+      expect(result.dashboards).toEqual([]);
+    });
+
+    it('sets isLoading to default', () => {
+      expect(result.isLoading).toBe(true);
+    });
+
+    it('sets errorText to default', () => {
+      expect(result.errorText).toEqual('');
+    });
+  });
+
+  describe('when dashboards exist on tableMetadata state', () => {
+    let result;
+    let testState;
+    beforeAll(() => {
+      testState = {
+        dashboards: {
+          dashboards: [dashboardSummary],
+          isLoading: false,
+          errorText: '',
+        },
+      };
+      result = mapStateToProps({
+        ...globalState,
+        tableMetadata: {
+          ...globalState.tableMetadata,
+          ...testState,
+        },
+      });
+    });
+
+    it('sets dashboards to default', () => {
+      expect(result.dashboards).toEqual(testState.dashboards.dashboards);
+    });
+  });
+});

--- a/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import ResourceList from 'components/common/ResourceList';
+import ShimmeringResourceLoader from 'components/common/ShimmeringResourceLoader';
+
+import { GlobalState } from 'ducks/rootReducer';
+
+import { DashboardResource } from 'interfaces';
+
+interface OwnProps {
+  itemsPerPage: number;
+  source: string;
+}
+
+interface StateFromProps {
+  dashboards: DashboardResource[];
+  isLoading: boolean;
+  errorText: string;
+}
+
+export type TableDashboardResourceListProps = OwnProps & StateFromProps;
+
+export class TableDashboardResourceList extends React.Component<
+  TableDashboardResourceListProps
+> {
+  render() {
+    const {
+      dashboards,
+      errorText,
+      isLoading,
+      itemsPerPage,
+      source,
+    } = this.props;
+    let content = <ShimmeringResourceLoader numItems={itemsPerPage} />;
+
+    if (!isLoading) {
+      content = (
+        <ResourceList
+          allItems={dashboards}
+          emptyText={errorText}
+          itemsPerPage={itemsPerPage}
+          source={source}
+        />
+      );
+    }
+
+    return content;
+  }
+}
+
+export const mapStateToProps = (state: GlobalState) => {
+  const relatedDashboards = state.tableMetadata.dashboards;
+  return {
+    dashboards: relatedDashboards ? relatedDashboards.dashboards : [],
+    isLoading: relatedDashboards ? relatedDashboards.isLoading : true,
+    errorText: relatedDashboards ? relatedDashboards.errorMessage : '',
+  };
+};
+
+export default connect<StateFromProps, {}, OwnProps>(
+  mapStateToProps,
+  null
+)(TableDashboardResourceList);

--- a/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/TableDashboardResourceList/index.tsx
@@ -38,7 +38,7 @@ export class TableDashboardResourceList extends React.Component<
       content = (
         <ResourceList
           allItems={dashboards}
-          emptyText={errorText}
+          emptyText={errorText || undefined}
           itemsPerPage={itemsPerPage}
           source={source}
         />

--- a/amundsen_application/static/js/components/TableDetail/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.spec.tsx
@@ -24,9 +24,10 @@ const setup = (
   );
   const props = {
     isLoading: false,
+    isLoadingDashboards: false,
+    numRelatedDashboards: 0,
     statusCode: 200,
     tableData: tableMetadata,
-    numRelatedDashboards: 0,
     getTableData: jest.fn(),
     ...routerProps,
     ...propOverrides,

--- a/amundsen_application/static/js/components/TableDetail/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.spec.tsx
@@ -26,6 +26,7 @@ const setup = (
     isLoading: false,
     statusCode: 200,
     tableData: tableMetadata,
+    numRelatedDashboards: 0,
     getTableData: jest.fn(),
     ...routerProps,
     ...propOverrides,

--- a/amundsen_application/static/js/components/TableDetail/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.spec.tsx
@@ -1,13 +1,20 @@
 import * as React from 'react';
 import * as History from 'history';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import { mocked } from 'ts-jest/utils';
 
-import { getMockRouterProps } from '../../fixtures/mockRouter';
-import { tableMetadata } from '../../fixtures/metadata/table';
+import { getMockRouterProps } from 'fixtures/mockRouter';
+import { tableMetadata } from 'fixtures/metadata/table';
 
-import LoadingSpinner from '../common/LoadingSpinner';
+import LoadingSpinner from 'components/common/LoadingSpinner';
+import TabsComponent from 'components/common/TabsComponent';
 
+import { indexDashboardsEnabled } from 'config/config-utils';
 import { TableDetail, TableDetailProps, MatchProps } from '.';
+
+jest.mock('config/config-utils', () => ({
+  indexDashboardsEnabled: jest.fn(),
+}));
 
 const setup = (
   propOverrides?: Partial<TableDetailProps>,
@@ -38,6 +45,24 @@ const setup = (
 };
 
 describe('TableDetail', () => {
+  describe('renderTabs', () => {
+    let wrapper;
+    beforeAll(() => {
+      wrapper = setup().wrapper;
+    });
+    it('renders one tab when dashboards are not enabled', () => {
+      mocked(indexDashboardsEnabled).mockImplementation(() => false);
+      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+      expect(content.find(TabsComponent).props().tabs.length).toEqual(1);
+    });
+
+    it('renders two tabs when dashboards are enabled', () => {
+      mocked(indexDashboardsEnabled).mockImplementation(() => true);
+      const content = shallow(<div>{wrapper.instance().renderTabs()}</div>);
+      expect(content.find(TabsComponent).props().tabs.length).toEqual(2);
+    });
+  });
+
   describe('render', () => {
     it('should render without problems', () => {
       expect(() => {

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -18,13 +18,13 @@ import LoadingSpinner from 'components/common/LoadingSpinner';
 import Flag from 'components/common/Flag';
 
 import ColumnList from 'components/TableDetail/ColumnList';
-import TableDashboardResourceList from 'components/TableDetail/TableDashboardResourceList';
 import DataPreviewButton from 'components/TableDetail/DataPreviewButton';
 import ExploreButton from 'components/TableDetail/ExploreButton';
 import FrequentUsers from 'components/TableDetail/FrequentUsers';
 import LineageLink from 'components/TableDetail/LineageLink';
 import OwnerEditor from 'components/TableDetail/OwnerEditor';
 import SourceLink from 'components/TableDetail/SourceLink';
+import TableDashboardResourceList from 'components/TableDetail/TableDashboardResourceList';
 import TableDescEditableText from 'components/TableDetail/TableDescEditableText';
 import TableHeaderBullets from 'components/TableDetail/TableHeaderBullets';
 import TableIssues from 'components/TableDetail/TableIssues';
@@ -58,9 +58,10 @@ const TABLE_SOURCE = 'table_page';
 
 export interface StateFromProps {
   isLoading: boolean;
+  isLoadingDashboards: boolean;
+  numRelatedDashboards: number;
   statusCode?: number;
   tableData: TableMetadata;
-  numRelatedDashboards: number;
 }
 export interface DispatchFromProps {
   getTableData: (
@@ -141,6 +142,11 @@ export class TableDetail extends React.Component<
     });
 
     if (indexDashboardsEnabled()) {
+      const loadingTitle = (
+        <div className="tab-title">
+          Dashboards <LoadingSpinner />
+        </div>
+      );
       tabInfo.push({
         content: (
           <TableDashboardResourceList
@@ -149,7 +155,9 @@ export class TableDetail extends React.Component<
           />
         ),
         key: 'dashboards',
-        title: `Dashboards (${this.props.numRelatedDashboards})`,
+        title: this.props.isLoadingDashboards
+          ? loadingTitle
+          : `Dashboards (${this.props.numRelatedDashboards})`,
       });
     }
 
@@ -310,6 +318,9 @@ export const mapStateToProps = (state: GlobalState) => {
     numRelatedDashboards: state.tableMetadata.dashboards
       ? state.tableMetadata.dashboards.dashboards.length
       : 0,
+    isLoadingDashboards: state.tableMetadata.dashboards
+      ? state.tableMetadata.dashboards.isLoading
+      : true,
   };
 };
 

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -16,10 +16,10 @@ import TabsComponent from 'components/common/TabsComponent';
 import EditableText from 'components/common/EditableText';
 import LoadingSpinner from 'components/common/LoadingSpinner';
 import Flag from 'components/common/Flag';
-import ResourceList from 'components/common/ResourceList';
 
-import DataPreviewButton from 'components/TableDetail/DataPreviewButton';
 import ColumnList from 'components/TableDetail/ColumnList';
+import TableDashboardResourceList from 'components/TableDetail/TableDashboardResourceList';
+import DataPreviewButton from 'components/TableDetail/DataPreviewButton';
 import ExploreButton from 'components/TableDetail/ExploreButton';
 import FrequentUsers from 'components/TableDetail/FrequentUsers';
 import LineageLink from 'components/TableDetail/LineageLink';
@@ -37,6 +37,7 @@ import EditableSection from 'components/common/EditableSection';
 
 import {
   getSourceIconClass,
+  indexDashboardsEnabled,
   issueTrackingEnabled,
   notificationsEnabled,
 } from 'config/config-utils';
@@ -59,6 +60,7 @@ export interface StateFromProps {
   isLoading: boolean;
   statusCode?: number;
   tableData: TableMetadata;
+  numRelatedDashboards: number;
 }
 export interface DispatchFromProps {
   getTableData: (
@@ -138,18 +140,18 @@ export class TableDetail extends React.Component<
       title: `Columns (${this.props.tableData.columns.length})`,
     });
 
-    // Dashboard content
-    tabInfo.push({
-      content: (
-        <ResourceList
-          allItems={this.props.tableData.dashboards}
-          itemsPerPage={DASHBOARDS_PER_PAGE}
-          source={TABLE_SOURCE}
-        />
-      ),
-      key: 'dashboards',
-      title: `Dashboards (${this.props.tableData.dashboards.length})`,
-    });
+    if (indexDashboardsEnabled()) {
+      tabInfo.push({
+        content: (
+          <TableDashboardResourceList
+            itemsPerPage={DASHBOARDS_PER_PAGE}
+            source={TABLE_SOURCE}
+          />
+        ),
+        key: 'dashboards',
+        title: `Dashboards (${this.props.numRelatedDashboards})`,
+      });
+    }
 
     return <TabsComponent tabs={tabInfo} defaultTab="columns" />;
   }
@@ -305,6 +307,9 @@ export const mapStateToProps = (state: GlobalState) => {
     isLoading: state.tableMetadata.isLoading,
     statusCode: state.tableMetadata.statusCode,
     tableData: state.tableMetadata.tableData,
+    numRelatedDashboards: state.tableMetadata.dashboards
+      ? state.tableMetadata.dashboards.dashboards.length
+      : 0,
   };
 };
 

--- a/amundsen_application/static/js/components/TableDetail/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/styles.scss
@@ -22,4 +22,14 @@
       }
     }
   }
+
+  .tab-title {
+    display: flex;
+
+    .loading-spinner {
+      height: 20px;
+      margin: 0 0 0 $spacer-1/2;
+      width: 20px;
+    }
+  }
 }

--- a/amundsen_application/static/js/components/common/ResourceList/styles.scss
+++ b/amundsen_application/static/js/components/common/ResourceList/styles.scss
@@ -23,7 +23,8 @@
   .empty-message {
     display: flex;
     justify-content: center;
-    margin-top: $spacer-4;
+    margin: $spacer-4 $spacer-4 0;
+    word-break: break-all;
   }
 }
 

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
@@ -37,6 +37,7 @@ describe('helpers', () => {
     };
     mockRelatedDashboardsResponseData = {
       dashboards: relatedDashboards,
+      msg: '',
     };
     mockResponseData = {
       tableData: tableResponseData,
@@ -80,10 +81,7 @@ describe('helpers', () => {
 
   describe('getTableDataFromResponseData', () => {
     it('uses the filterFromObj method', () => {
-      Helpers.getTableDataFromResponseData(
-        mockResponseData,
-        mockRelatedDashboardsResponseData
-      );
+      Helpers.getTableDataFromResponseData(mockResponseData);
 
       expect(filterFromObjSpy).toHaveBeenCalledWith(tableResponseData, [
         'owners',
@@ -94,23 +92,20 @@ describe('helpers', () => {
     describe('produces the final TableMetadata information', () => {
       it('contains the columns key', () => {
         const expected = 0;
-        const actual = Helpers.getTableDataFromResponseData(
-          mockResponseData,
-          mockRelatedDashboardsResponseData
-        ).columns.length;
+        const actual = Helpers.getTableDataFromResponseData(mockResponseData)
+          .columns.length;
 
         expect(actual).toEqual(expected);
       });
 
-      it('contains the dashboards key', () => {
+      /* it('contains the dashboards key', () => {
         const expected = 3;
         const actual = Helpers.getTableDataFromResponseData(
-          mockResponseData,
-          mockRelatedDashboardsResponseData
+          mockResponseData
         ).dashboards.length;
 
         expect(actual).toEqual(expected);
-      });
+      });*/
     });
   });
 

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.spec.ts
@@ -97,15 +97,6 @@ describe('helpers', () => {
 
         expect(actual).toEqual(expected);
       });
-
-      /* it('contains the dashboards key', () => {
-        const expected = 3;
-        const actual = Helpers.getTableDataFromResponseData(
-          mockResponseData
-        ).dashboards.length;
-
-        expect(actual).toEqual(expected);
-      });*/
     });
   });
 

--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -33,18 +33,15 @@ export function getRelatedDashboardSlug(key: string): string {
 }
 
 /**
- * Parses the response for table metadata and the related dashboard information to create a TableMetadata object
+ * Parses the response for table metadata information to create a TableMetadata object
  */
 export function getTableDataFromResponseData(
-  responseData: API.TableDataAPI,
-  relatedDashboardsData: API.RelatedDashboardDataAPI
+  responseData: API.TableDataAPI
 ): TableMetadata {
-  const mergedTableData = {
-    ...filterFromObj(responseData.tableData, ['owners', 'tags']),
-    ...filterFromObj(relatedDashboardsData, ['msg', 'status_code']),
-  };
-
-  return mergedTableData as TableMetadata;
+  return filterFromObj(responseData.tableData, [
+    'owners',
+    'tags',
+  ]) as TableMetadata;
 }
 
 /**

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -12,6 +12,8 @@ import {
   GetTableData,
   GetTableDataRequest,
   GetTableDataResponse,
+  GetTableDashboards,
+  GetTableDashboardsResponse,
   GetTableDescription,
   GetTableDescriptionRequest,
   GetTableDescriptionResponse,
@@ -82,9 +84,9 @@ export function getTableDataSuccess(
 export function getTableDashboardsResponse(
   dashboards: DashboardResource[],
   errorMessage: string = ''
-): any {
+): GetTableDashboardsResponse {
   return {
-    type: 'GetTableDashboards.RESPONSE',
+    type: GetTableDashboards.RESPONSE,
     payload: {
       dashboards,
       errorMessage,
@@ -296,7 +298,7 @@ export default function reducer(
   action
 ): TableMetadataReducerState {
   switch (action.type) {
-    case 'GetTableDashboards.RESPONSE':
+    case GetTableDashboards.RESPONSE:
       return {
         ...state,
         dashboards: {

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -1,4 +1,5 @@
 import {
+  DashboardResource,
   OwnerDict,
   PreviewData,
   PreviewQueryParams,
@@ -74,6 +75,19 @@ export function getTableDataSuccess(
       owners,
       statusCode,
       tags,
+    },
+  };
+}
+
+export function getTableDashboardsResponse(
+  dashboards: DashboardResource[],
+  errorMessage: string = ''
+): any {
+  return {
+    type: 'GetTableDashboards.RESPONSE',
+    payload: {
+      dashboards,
+      errorMessage,
     },
   };
 }
@@ -227,6 +241,11 @@ export function getPreviewDataSuccess(
 
 /* REDUCER */
 export interface TableMetadataReducerState {
+  dashboards?: {
+    isLoading: boolean;
+    dashboards: DashboardResource[];
+    errorMessage?: string;
+  };
   isLoading: boolean;
   lastIndexed: number;
   preview: {
@@ -247,7 +266,6 @@ export const initialTableDataState: TableMetadata = {
   badges: [],
   cluster: '',
   columns: [],
-  dashboards: [],
   database: '',
   is_editable: false,
   is_view: false,
@@ -278,14 +296,17 @@ export default function reducer(
   action
 ): TableMetadataReducerState {
   switch (action.type) {
-    case GetTableData.REQUEST:
+    case 'GetTableDashboards.RESPONSE':
       return {
         ...state,
-        isLoading: true,
-        preview: initialPreviewState,
-        tableData: initialTableDataState,
-        tableOwners: tableOwnersReducer(state.tableOwners, action),
+        dashboards: {
+          isLoading: false,
+          dashboards: action.payload.dashboards,
+          errorMessage: action.payload.errorMessage,
+        },
       };
+    case GetTableData.REQUEST:
+      return initialState;
     case GetTableData.FAILURE:
       return {
         ...state,

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -4,6 +4,7 @@ import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import * as API from './api/v0';
 
 import {
+  getTableDashboardsResponse,
   getTableDataFailure,
   getTableDataSuccess,
   getTableDescriptionFailure,
@@ -34,8 +35,8 @@ import {
 } from './types';
 
 export function* getTableDataWorker(action: GetTableDataRequest): SagaIterator {
+  const { key, searchIndex, source } = action.payload;
   try {
-    const { key, searchIndex, source } = action.payload;
     const { data, owners, statusCode, tags } = yield call(
       API.getTableData,
       key,
@@ -45,6 +46,13 @@ export function* getTableDataWorker(action: GetTableDataRequest): SagaIterator {
     yield put(getTableDataSuccess(data, owners, statusCode, tags));
   } catch (e) {
     yield put(getTableDataFailure());
+  }
+
+  try {
+    const { dashboards } = yield call(API.getTableDashboards, key);
+    yield put(getTableDashboardsResponse(dashboards));
+  } catch (error) {
+    yield put(getTableDashboardsResponse([], error.msg));
   }
 }
 export function* getTableDataWatcher(): SagaIterator {

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -44,15 +44,15 @@ export function* getTableDataWorker(action: GetTableDataRequest): SagaIterator {
       source
     );
     yield put(getTableDataSuccess(data, owners, statusCode, tags));
+
+    try {
+      const { dashboards } = yield call(API.getTableDashboards, key);
+      yield put(getTableDashboardsResponse(dashboards));
+    } catch (error) {
+      yield put(getTableDashboardsResponse([], error.msg));
+    }
   } catch (e) {
     yield put(getTableDataFailure());
-  }
-
-  try {
-    const { dashboards } = yield call(API.getTableDashboards, key);
-    yield put(getTableDashboardsResponse(dashboards));
-  } catch (error) {
-    yield put(getTableDashboardsResponse([], error.msg));
   }
 }
 export function* getTableDataWatcher(): SagaIterator {

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -374,7 +374,7 @@ describe('tableMetadata ducks', () => {
       });
     });
 
-    describe('getTableDataWorker', () => {
+    /*describe('getTableDataWorker', () => {
       it('executes flow for getting table data', () => {
         const mockResult = {
           data: expectedData,
@@ -409,7 +409,7 @@ describe('tableMetadata ducks', () => {
           .next()
           .isDone();
       });
-    });
+    });*/
 
     describe('getTableDescriptionWatcher', () => {
       it('takes every GetTableDescription.REQUEST with getTableDescriptionWorker', () => {

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -302,14 +302,17 @@ describe('tableMetadata ducks', () => {
       const mockDashboards = [dashboardSummary];
       const mockMessage = 'test';
       expect(
-        reducer(testState, getTableDashboardsResponse(mockDashboards, mockMessage))
+        reducer(
+          testState,
+          getTableDashboardsResponse(mockDashboards, mockMessage)
+        )
       ).toEqual({
         ...testState,
         dashboards: {
           isLoading: false,
           dashboards: mockDashboards,
           errorMessage: mockMessage,
-        }
+        },
       });
     });
 
@@ -400,7 +403,7 @@ describe('tableMetadata ducks', () => {
           tags: expectedTags,
         };
         const mockDashboardsResult = {
-          dashboards: [dashboardSummary]
+          dashboards: [dashboardSummary],
         };
         testSaga(
           getTableDataWorker,
@@ -420,9 +423,7 @@ describe('tableMetadata ducks', () => {
           .next()
           .call(API.getTableDashboards, testKey)
           .next(mockDashboardsResult)
-          .put(
-            getTableDashboardsResponse(mockDashboardsResult.dashboards)
-          )
+          .put(getTableDashboardsResponse(mockDashboardsResult.dashboards))
           .next()
           .isDone();
       });

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -10,6 +10,7 @@ import {
   User,
 } from 'interfaces';
 
+import { dashboardSummary } from 'fixtures/metadata/dashboard';
 import globalState from 'fixtures/globalState';
 
 import * as API from '../api/v0';
@@ -18,6 +19,7 @@ import reducer, {
   getTableData,
   getTableDataFailure,
   getTableDataSuccess,
+  getTableDashboardsResponse,
   getTableDescription,
   getTableDescriptionFailure,
   getTableDescriptionSuccess,
@@ -296,6 +298,21 @@ describe('tableMetadata ducks', () => {
       expect(reducer(testState, { type: 'INVALID.ACTION' })).toEqual(testState);
     });
 
+    it('should handle GetTableDashboards.RESPONSE', () => {
+      const mockDashboards = [dashboardSummary];
+      const mockMessage = 'test';
+      expect(
+        reducer(testState, getTableDashboardsResponse(mockDashboards, mockMessage))
+      ).toEqual({
+        ...testState,
+        dashboards: {
+          isLoading: false,
+          dashboards: mockDashboards,
+          errorMessage: mockMessage,
+        }
+      });
+    });
+
     it('should handle GetTableDescription.FAILURE', () => {
       expect(
         reducer(testState, getTableDescriptionFailure(expectedData))
@@ -374,13 +391,16 @@ describe('tableMetadata ducks', () => {
       });
     });
 
-    /* describe('getTableDataWorker', () => {
+    describe('getTableDataWorker', () => {
       it('executes flow for getting table data', () => {
         const mockResult = {
           data: expectedData,
           owners: expectedOwners,
           statusCode: expectedStatus,
           tags: expectedTags,
+        };
+        const mockDashboardsResult = {
+          dashboards: [dashboardSummary]
         };
         testSaga(
           getTableDataWorker,
@@ -398,10 +418,16 @@ describe('tableMetadata ducks', () => {
             )
           )
           .next()
+          .call(API.getTableDashboards, testKey)
+          .next(mockDashboardsResult)
+          .put(
+            getTableDashboardsResponse(mockDashboardsResult.dashboards)
+          )
+          .next()
           .isDone();
       });
 
-      it('handles request error', () => {
+      it('handles request error on getTableData', () => {
         testSaga(getTableDataWorker, getTableData(testKey))
           .next()
           .throw(new Error())
@@ -409,7 +435,7 @@ describe('tableMetadata ducks', () => {
           .next()
           .isDone();
       });
-    });*/
+    });
 
     describe('getTableDescriptionWatcher', () => {
       it('takes every GetTableDescription.REQUEST with getTableDescriptionWorker', () => {

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -374,7 +374,7 @@ describe('tableMetadata ducks', () => {
       });
     });
 
-    /*describe('getTableDataWorker', () => {
+    /* describe('getTableDataWorker', () => {
       it('executes flow for getting table data', () => {
         const mockResult = {
           data: expectedData,

--- a/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -1,4 +1,5 @@
 import {
+  DashboardResource,
   OwnerDict,
   PreviewData,
   PreviewQueryParams,
@@ -27,6 +28,17 @@ export interface GetTableDataResponse {
     data: TableMetadata;
     owners: OwnerDict;
     tags: Tag[];
+  };
+}
+
+export enum GetTableDashboards {
+  RESPONSE = 'amundsen/tableMetadata/GET_TABLE_DASHBOARDS_RESPONSE',
+}
+export interface GetTableDashboardsResponse {
+  type: GetTableDashboards.RESPONSE;
+  payload: {
+    dashboards: DashboardResource[];
+    errorMessage: string;
   };
 }
 

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -158,7 +158,6 @@ const globalState: GlobalState = {
       badges: [],
       cluster: '',
       columns: [],
-      dashboards: [],
       database: '',
       is_editable: false,
       is_view: false,

--- a/amundsen_application/static/js/fixtures/metadata/table.ts
+++ b/amundsen_application/static/js/fixtures/metadata/table.ts
@@ -93,7 +93,6 @@ export const tableMetadata: TableMetadata = {
       ],
     },
   ],
-  dashboards: [],
   database: 'hive',
   description:
     'One row per ride request, showing all stages of the ride funnel. ',

--- a/amundsen_application/static/js/interfaces/TableMetadata.ts
+++ b/amundsen_application/static/js/interfaces/TableMetadata.ts
@@ -1,7 +1,6 @@
 import { UpdateMethod } from './Enums';
 import { User } from './User';
 import { Badge } from './Tags';
-import { DashboardResource } from './Resources';
 
 interface PartitionData {
   is_partitioned: boolean;
@@ -79,7 +78,6 @@ export interface TableMetadata {
   badges: Badge[];
   cluster: string;
   columns: TableColumn[];
-  dashboards: DashboardResource[];
   database: string;
   is_editable: boolean;
   is_view: boolean;

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -1036,8 +1036,8 @@ class MetadataTest(unittest.TestCase):
             )
             self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
             expected = {
-                'dashboards': {},
-                'msg': 'Encountered error: Related Dashboard Metadata request failed',
+                'dashboards': [],
+                'msg': 'Encountered 400 Error: Related dashboard metadata request failed',
                 'status_code': 400
             }
             self.assertEqual(response.json, expected)


### PR DESCRIPTION
### Summary of Changes

This PR fixes the issue of the `TableDetail` page being unable to render when the metadata endpoint for related dashboards is not properly implemented or otherwise has an issue and returns a non-200 code. The cause of the issue was coupling the request for table metadata with the request for related dashboards -- if the related dashboard request failed then the entire page failed to load. 

This PR separate the logic of the related dashboards feature into a separate component and decouples some API calls. Support also includes showing error text from the response when there is an issue with the related dashboard request. 

Further details implementation details have been included inline.

### Tests

Tests updated to reflect changes.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
