### PR TITLE
fix: Make sure not to crash user search api when search service returns empty dict

### DIFF
--- a/amundsen_application/api/search/v0.py
+++ b/amundsen_application/api/search/v0.py
@@ -168,7 +168,7 @@ def _search_user(*, search_term: str, page_index: int, search_type: str) -> Dict
 
         if status_code == HTTPStatus.OK:
             results_dict['msg'] = 'Success'
-            results = response.json().get('results')
+            results = response.json().get('results', list())
             users['results'] = [_map_user_result(result) for result in results]
             users['total_results'] = response.json().get('total_results')
         else:

--- a/amundsen_application/api/search/v0.py
+++ b/amundsen_application/api/search/v0.py
@@ -170,7 +170,7 @@ def _search_user(*, search_term: str, page_index: int, search_type: str) -> Dict
             results_dict['msg'] = 'Success'
             results = response.json().get('results', list())
             users['results'] = [_map_user_result(result) for result in results]
-            users['total_results'] = response.json().get('total_results')
+            users['total_results'] = response.json().get('total_results', 0)
         else:
             message = 'Encountered error: Search request failed'
             results_dict['msg'] = message

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -299,7 +299,7 @@ class SearchUser(unittest.TestCase):
 
             users = data.get('users')
             self.assertEqual(len(users.get('results')), 0)
-            self.assertEqual(len(users.get('total_results')), 0)
+            self.assertEqual(users.get('total_results'), 0)
 
     @responses.activate
     def test_search_user_success(self) -> None:

--- a/tests/unit/api/search/test_v0.py
+++ b/tests/unit/api/search/test_v0.py
@@ -284,6 +284,24 @@ class SearchUser(unittest.TestCase):
             self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
 
     @responses.activate
+    def test_search_user_success_if_no_response_from_search(self) -> None:
+        """
+        Test request success
+        :return:
+        """
+        responses.add(responses.GET, local_app.config['SEARCHSERVICE_BASE'] + SEARCH_USER_ENDPOINT,
+                      json={}, status=HTTPStatus.OK)
+
+        with local_app.test_client() as test:
+            response = test.get(self.fe_flask_endpoint, query_string=dict(query='test', page_index='0'))
+            data = json.loads(response.data)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+
+            users = data.get('users')
+            self.assertEqual(len(users.get('results')), 0)
+            self.assertEqual(len(users.get('total_results')), 0)
+
+    @responses.activate
     def test_search_user_success(self) -> None:
         """
         Test request success


### PR DESCRIPTION
### Summary of Changes

With the changes introduces in this PR: https://github.com/lyft/amundsensearchlibrary/pull/111 , if your user index feature is not implemented in the search i.e., has `pass`, then the frontend does not work and crashes. This PR will fix this issue. 

### Tests

Added the corresponding test case!

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
