### PR TITLE
feat: Support markdown for dashboard descriptions

### DIFF
--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -119,15 +119,18 @@ $aside-separation-space: 40px;
 
       .editable-text {
         font-size: 16px;
-
-        .markdown-wrapper {
-          font-size: 16px;
-        }
       }
 
       .avatar-label-component {
         .avatar-label {
           color: $text-primary;
+        }
+      }
+
+      .markdown-wrapper {
+        font-size: 16px;
+        > p {
+          margin: 0;
         }
       }
     }

--- a/amundsen_application/static/js/components/DashboardPage/index.spec.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactMarkdown from 'react-markdown';
 import * as History from 'history';
 
 import { shallow } from 'enzyme';
@@ -182,6 +183,14 @@ describe('DashboardPage', () => {
     });
 
     describe('renders description', () => {
+      it('using a ReactMarkdown component', () => {
+        const markdown = wrapper.find(ReactMarkdown);
+        expect(markdown.exists()).toBe(true);
+        expect(markdown.props()).toMatchObject({
+          source: props.dashboard.description,
+        });
+      });
+
       it('with link to add description if none exists', () => {
         const { wrapper } = setup({
           dashboard: {

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -217,9 +217,6 @@ export class DashboardPage extends React.Component<
                 <div className="markdown-wrapper">
                   <ReactMarkdown source={dashboard.description} />
                 </div>
-                /*<div className="body-2 and text-primary">
-                  {dashboard.description}
-                </div>*/
               )}
               {!hasDescription && (
                 <a

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import { RouteComponentProps } from 'react-router';
 import * as qs from 'simple-query-string';
 
+import * as ReactMarkdown from 'react-markdown';
+
 import AvatarLabel from 'components/common/AvatarLabel';
 import Breadcrumb from 'components/common/Breadcrumb';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
@@ -212,9 +214,12 @@ export class DashboardPage extends React.Component<
               )}`}
             >
               {hasDescription && (
-                <div className="body-2 and text-primary">
-                  {dashboard.description}
+                <div className="markdown-wrapper">
+                  <ReactMarkdown source={dashboard.description} />
                 </div>
+                /*<div className="body-2 and text-primary">
+                  {dashboard.description}
+                </div>*/
               )}
               {!hasDescription && (
                 <a

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -137,6 +137,7 @@ class MetadataTest(unittest.TestCase):
                     'text': 'description c'
                 },
             ],
+            'resource_reports': [],
             'table_writer': {
                 'application_url': 'https://test-test.test.test',
                 'name': 'test_name',

--- a/tests/unit/api/metadata/test_v0.py
+++ b/tests/unit/api/metadata/test_v0.py
@@ -61,6 +61,7 @@ class MetadataTest(unittest.TestCase):
             'schema': 'test_schema',
             'name': 'test_table',
             'description': 'This is a test',
+            'resource_reports': [],
             'programmatic_descriptions': [
                 {'source': 'c_1', 'text': 'description c'},
                 {'source': 'a_1', 'text': 'description a'},


### PR DESCRIPTION
### Summary of Changes

This PR supports markdown in dashboard descriptions. 
1. Use `ReactMarkdown` to display dashboard descriptions
2. Update styles to ensure font size is `16px`, and removing the extra margins from the `<p>` (paragraph) element used in `ReactMarkdown`. This is needed to keep things inline with design specifications.

### Tests

1. Updates `DashboardPage` tests to reflect changes.

### Documentation

N/A, but will be called out in the next release.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
