### PR TITLE
fix: Getting tooltip on edit button of Column Description if un-editable

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/ColumnList/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnList/index.tsx
@@ -6,10 +6,14 @@ import './styles.scss';
 
 interface ColumnListProps {
   columns?: TableColumn[];
+  editText?: string;
+  editUrl?: string;
 }
 
 const ColumnList: React.SFC<ColumnListProps> = ({
   columns,
+  editText,
+  editUrl,
 }: ColumnListProps) => {
   if (columns.length < 1) {
     return <div />;
@@ -17,7 +21,13 @@ const ColumnList: React.SFC<ColumnListProps> = ({
   }
 
   const columnList = columns.map((entry, index) => (
-    <ColumnListItem key={`column:${index}`} data={entry} index={index} />
+    <ColumnListItem
+      key={`column:${index}`}
+      data={entry}
+      index={index}
+      editText={editText}
+      editUrl={editUrl}
+    />
   ));
 
   return <ul className="column-list list-group">{columnList}</ul>;
@@ -25,6 +35,8 @@ const ColumnList: React.SFC<ColumnListProps> = ({
 
 ColumnList.defaultProps = {
   columns: [] as TableColumn[],
+  editText: '',
+  editUrl: '',
 };
 
 export default ColumnList;

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -7,6 +7,7 @@ import {
   ColumnListItemProps,
   mapDispatchToProps,
 } from 'components/TableDetail/ColumnListItem';
+import EditableSection from 'components/common/EditableSection';
 import ColumnStats from 'components/TableDetail/ColumnStats';
 import AppConfig from 'config/config';
 import * as UtilMethods from 'ducks/utilMethods';
@@ -34,8 +35,8 @@ describe('ColumnListItem', () => {
       },
       index: 0,
       openRequestDescriptionDialog: jest.fn(),
-      editText: '',
-      editUrl: '',
+      editText: 'Click to edit discription in source',
+      editUrl: 'source/test_column_name',
       ...propOverrides,
     };
 
@@ -126,6 +127,19 @@ describe('ColumnListItem', () => {
       expect(newWrapper.find('.expanded-content').exists()).toBe(true);
       expect(newWrapper.find(ColumnDescEditableText).exists()).toBe(true);
       expect(newWrapper.find(ColumnStats).exists()).toBe(true);
+    });
+
+    it('renders EditableSection with correct edit text and Url when expanded', () => {
+      instance.setState({ isExpanded: true });
+      const newWrapper = shallow(instance.render());
+      expect(newWrapper.find(EditableSection).exists()).toBe(true);
+      const editableSection = newWrapper.find(EditableSection);
+      expect(editableSection.props()).toMatchObject({
+        title: 'Description',
+        readOnly: !props.data.is_editable,
+        editText: props.editText,
+        editUrl: props.editUrl,
+      });
     });
 
     describe('when not expanded', () => {

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -34,6 +34,8 @@ describe('ColumnListItem', () => {
       },
       index: 0,
       openRequestDescriptionDialog: jest.fn(),
+      editText: '',
+      editUrl: '',
       ...propOverrides,
     };
 

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -26,6 +26,8 @@ interface DispatchFromProps {
 interface OwnProps {
   data: TableColumn;
   index: number;
+  editText: string;
+  editUrl: string;
 }
 
 interface ColumnListItemState {
@@ -170,6 +172,8 @@ export class ColumnListItem extends React.Component<
                 <EditableSection
                   title="Description"
                   readOnly={!metadata.is_editable}
+                  editText={this.props.editText}
+                  editUrl={this.props.editUrl}
                 >
                   <ColumnDescEditableText
                     columnIndex={this.props.index}

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -135,12 +135,18 @@ export class TableDetail extends React.Component<
     return `${params.database}://${params.cluster}.${params.schema}/${params.table}`;
   }
 
-  renderTabs() {
+  renderTabs(editText, editUrl) {
     const tabInfo = [];
 
     // Default Column content
     tabInfo.push({
-      content: <ColumnList columns={this.props.tableData.columns} />,
+      content: (
+        <ColumnList
+          columns={this.props.tableData.columns}
+          editText={editText}
+          editUrl={editUrl}
+        />
+      ),
       key: 'columns',
       title: `Columns (${this.props.tableData.columns.length})`,
     });
@@ -307,7 +313,9 @@ export class TableDetail extends React.Component<
                 </section>
               ))}
             </aside>
-            <main className="right-panel">{this.renderTabs()}</main>
+            <main className="right-panel">
+              {this.renderTabs(editText, editUrl)}
+            </main>
           </div>
         </div>
       );


### PR DESCRIPTION
### Summary of Changes

We have provided feature for making table and column description un-editable, in this PR we are providing link to source file from column's edit button if someone wants to change column description at source file.
Edit link and source is same as table source link. 

### Tests
NA

### Documentation

NA

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
