### PR TITLE
fix: Footer consistently in loading state

### DIFF
--- a/amundsen_application/static/js/components/Footer/index.tsx
+++ b/amundsen_application/static/js/components/Footer/index.tsx
@@ -33,6 +33,10 @@ export class Footer extends React.Component<FooterProps> {
     this.props.getLastIndexed();
   }
 
+  componentDidUpdate() {
+    this.props.getLastIndexed();
+  }
+
   generateDateTimeString = () => {
     return formatDateTimeLong({ epochTimestamp: this.props.lastIndexed });
   };

--- a/amundsen_application/static/js/components/Footer/index.tsx
+++ b/amundsen_application/static/js/components/Footer/index.tsx
@@ -36,10 +36,6 @@ export class Footer extends React.Component<FooterProps> {
     this.props.getLastIndexed();
   }
 
-  componentDidUpdate() {
-    this.props.getLastIndexed();
-  }
-
   generateDateTimeString = () => {
     return formatDateTimeLong({ epochTimestamp: this.props.lastIndexed });
   };

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -309,7 +309,10 @@ export default function reducer(
         },
       };
     case GetTableData.REQUEST:
-      return initialState;
+      return {
+        ...initialState,
+        lastIndexed: state.lastIndexed,
+      };
     case GetTableData.FAILURE:
       return {
         ...state,

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -309,10 +309,7 @@ export default function reducer(
         },
       };
     case GetTableData.REQUEST:
-      return {
-        ...initialState,
-        lastIndexed: state.lastIndexed,
-      };
+      return initialState;
     case GetTableData.FAILURE:
       return {
         ...state,


### PR DESCRIPTION
### Summary of Changes

Footer shows when did Amundsen last indexed, it loads properly for first time but when we navigate to other pages it goes into loading state forever.

### Tests

No addition

### Documentation

No addition

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
