### PR TITLE
fix: wrap preview grid to 50px

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
@@ -36,7 +36,6 @@
       .grid-header.grid-cell {
         background-color: $body-bg-secondary;
         height: 40px;
-        max-width: 50px;
       }
 
       .grid-cell {
@@ -47,9 +46,9 @@
         font-size: 12px;
         height: 32px;
         justify-content: center;
-        max-width: 50px;
+        max-width: 300px;
         min-width: 0;
-        overflow-wrap: break-word;
+        overflow: hidden;
         padding: 8px;
         text-align: center;
         white-space: nowrap;

--- a/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
@@ -46,7 +46,9 @@
         font-size: 12px;
         height: 32px;
         justify-content: center;
+        max-width: 50px;
         min-width: 0;
+        overflow-wrap: break-word;
         padding: 8px;
         text-align: center;
         white-space: nowrap;

--- a/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
+++ b/amundsen_application/static/js/components/TableDetail/DataPreviewButton/styles.scss
@@ -36,6 +36,7 @@
       .grid-header.grid-cell {
         background-color: $body-bg-secondary;
         height: 40px;
+        max-width: 50px;
       }
 
       .grid-cell {


### PR DESCRIPTION
### Summary of Changes

Currently each preview column could be very long if the actual data is. Two things in the pr:
1. set a max-width of each grid
2. do a text wrap

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
