### PR TITLE
fix: Wrap dashboard description in .editable-text to enforce description styles

### DIFF
--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -222,8 +222,10 @@ export class DashboardPage extends React.Component<
               )}`}
             >
               {hasDescription && (
-                <div className="markdown-wrapper">
-                  <ReactMarkdown source={dashboard.description} />
+                <div className="editable-text">
+                  <div className="markdown-wrapper">
+                    <ReactMarkdown source={dashboard.description} />
+                  </div>
                 </div>
               )}
               {!hasDescription && (


### PR DESCRIPTION
### Summary of Changes

Right now, dashboard descriptions aren't styled the same way as table descriptions, since dashboard descriptions are not in `.editable-text`. The main consequence of this is that headings in dashboard descriptions can be very large.

![image](https://user-images.githubusercontent.com/745011/88435026-64b92100-cdcf-11ea-8ee7-5492acca19c7.png)

### Tests

None

### Documentation

None

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes, including screenshots of any UI changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
