### PR TITLE
fix: Apply column description length configuration

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 
 import ColumnDescEditableText from 'components/TableDetail/ColumnDescEditableText';
 import ColumnStats from 'components/TableDetail/ColumnStats';
-import { notificationsEnabled } from 'config/config-utils';
+import { notificationsEnabled, getMaxLength } from 'config/config-utils';
 import { openRequestDescriptionDialog } from 'ducks/notification/reducer';
 import { OpenRequestAction } from 'ducks/notification/types';
 import { logClick } from 'ducks/utilMethods';
@@ -181,6 +181,7 @@ export class ColumnListItem extends React.Component<
                   <ColumnDescEditableText
                     columnIndex={this.props.index}
                     editable={metadata.is_editable}
+                    maxLength={getMaxLength('columnDescLength')}
                     value={metadata.description}
                   />
                 </EditableSection>

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -11,7 +11,8 @@ import { GlobalState } from 'ducks/rootReducer';
 import { getTableData } from 'ducks/tableMetadata/reducer';
 import { GetTableDataRequest } from 'ducks/tableMetadata/types';
 
-import AppConfig from 'config/config';
+import { getMaxLength } from 'config/config-utils';
+
 import BadgeList from 'components/common/BadgeList';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
 import Breadcrumb from 'components/common/Breadcrumb';
@@ -246,7 +247,7 @@ export class TableDetail extends React.Component<
                 editUrl={editUrl}
               >
                 <TableDescEditableText
-                  maxLength={AppConfig.editableText.tableDescLength}
+                  maxLength={getMaxLength('tableDescLength')}
                   value={data.description}
                   editable={data.is_editable}
                 />

--- a/amundsen_application/static/js/components/TableDetail/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/index.tsx
@@ -11,7 +11,13 @@ import { GlobalState } from 'ducks/rootReducer';
 import { getTableData } from 'ducks/tableMetadata/reducer';
 import { GetTableDataRequest } from 'ducks/tableMetadata/types';
 
-import { getMaxLength } from 'config/config-utils';
+import {
+  getMaxLength,
+  getSourceIconClass,
+  indexDashboardsEnabled,
+  issueTrackingEnabled,
+  notificationsEnabled,
+} from 'config/config-utils';
 
 import BadgeList from 'components/common/BadgeList';
 import BookmarkIcon from 'components/common/Bookmark/BookmarkIcon';
@@ -38,13 +44,6 @@ import TagInput from 'components/Tags/TagInput';
 import { ResourceType, TableMetadata } from 'interfaces';
 
 import EditableSection from 'components/common/EditableSection';
-
-import {
-  getSourceIconClass,
-  indexDashboardsEnabled,
-  issueTrackingEnabled,
-  notificationsEnabled,
-} from 'config/config-utils';
 
 import { formatDateTimeShort } from 'utils/dateUtils';
 import { getLoggingParams } from 'utils/logUtils';

--- a/amundsen_application/static/js/config/config-utils.ts
+++ b/amundsen_application/static/js/config/config-utils.ts
@@ -170,3 +170,11 @@ export function generateExploreUrl(tableData: TableMetadata): string {
     tableData.name
   );
 }
+
+/**
+ * Gets the max length for items with a configurable max length.
+ * Currently only applied to `editableText`, but method can be extended for future cases
+ */
+export function getMaxLength(key: string) {
+  return AppConfig.editableText[key];
+}


### PR DESCRIPTION
### Summary of Changes

We were missing support to apply the columns description length configuration to the `ColumnDescEditableText`.


### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
