### PR TITLE
fix: Update markdown wrapper styles

### DIFF
--- a/amundsen_application/static/css/_layouts.scss
+++ b/amundsen_application/static/css/_layouts.scss
@@ -131,8 +131,20 @@ $aside-separation-space: 40px;
       .markdown-wrapper {
         font-size: 16px;
 
-        > p {
+        // Remove extra margin form text elements
+        > p,
+        ul,
+        ol {
           margin: 0;
+        }
+
+        // Restrict max size of header elements
+        h1,
+        h2,
+        h3 {
+          font-size: 20px;
+          font-weight: $font-weight-header-bold;
+          line-height: 28px;
         }
       }
     }

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -222,10 +222,8 @@ export class DashboardPage extends React.Component<
               )}`}
             >
               {hasDescription && (
-                <div className="editable-text">
-                  <div className="markdown-wrapper">
-                    <ReactMarkdown source={dashboard.description} />
-                  </div>
+                <div className="markdown-wrapper">
+                  <ReactMarkdown source={dashboard.description} />
                 </div>
               )}
               {!hasDescription && (

--- a/amundsen_application/static/js/components/common/EditableText/styles.scss
+++ b/amundsen_application/static/js/components/common/EditableText/styles.scss
@@ -8,22 +8,6 @@
   .markdown-wrapper {
     font-size: 14px;
     word-break: break-word;
-
-    // Remove extra margin form text elements
-    > p,
-    ul,
-    ol {
-      margin: 0;
-    }
-
-    // Restrict max size of header elements
-    h1,
-    h2,
-    h3 {
-      font-size: 20px;
-      font-weight: $font-weight-header-bold;
-      line-height: 28px;
-    }
   }
 
   .edit-link {


### PR DESCRIPTION
### Summary of Changes

This PR is an extension of https://github.com/lyft/amundsenfrontendlibrary/pull/520, updating the fix to use the approach of taking `markdown-wrapper` styles that were only applied to `EditableText`, and instead applies them to all `markdown-wrapper` components used within the resource detail left panel layout.

See https://github.com/lyft/amundsenfrontendlibrary/pull/520#issuecomment-665305296 for further context.

### Tests

N/A. CSS changes only.

### Documentation

N/A. CSS changes only.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
