### PR TITLE
fix: Correctly set column editable state

### DIFF
--- a/amundsen_application/api/utils/metadata_utils.py
+++ b/amundsen_application/api/utils/metadata_utils.py
@@ -96,14 +96,15 @@ def marshall_table_full(table_dict: Dict) -> Dict:
     for reader_object in readers:
         reader_object['user'] = _map_user_object_to_schema(reader_object['user'])
 
-    # If order is provided, we sort the column based on the pre-defined order
-    if app.config['COLUMN_STAT_ORDER']:
-        columns = results['columns']
-        for col in columns:
+    columns = results['columns']
+    for col in columns:
+        # Set editable state
+        col['is_editable'] = is_editable
+        # If order is provided, we sort the column based on the pre-defined order
+        if app.config['COLUMN_STAT_ORDER']:
             # the stat_type isn't defined in COLUMN_STAT_ORDER, we just use the max index for sorting
             col['stats'].sort(key=lambda x: app.config['COLUMN_STAT_ORDER'].
                               get(x['stat_type'], len(app.config['COLUMN_STAT_ORDER'])))
-            col['is_editable'] = is_editable
 
     # TODO: Add the 'key' or 'id' to the base TableSchema
     results['key'] = f'{table.database}://{table.cluster}.{table.schema}/{table.name}'


### PR DESCRIPTION
### Summary of Changes

The for loop where the column editable state got set was done written incorrectly. It was nested inside a check for `app.config['COLUMN_STAT_ORDER']`, so it would not be set if the configuration did not exist. This PR updates the logic to work as intended. 

### Tests

N/A

### Documentation

Will be called out in release. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
