### PR TITLE
fix: Make user_id the id to use for the Owner operations

### DIFF
--- a/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/helpers.ts
@@ -50,10 +50,9 @@ export function getTableDataFromResponseData(
 export function getTableOwnersFromResponseData(
   responseData: API.TableDataAPI
 ): OwnerDict {
-  // TODO: owner needs proper id, until then we have to remember that we are using display_name
   const ownerObj = responseData.tableData.owners.reduce(
     (resultObj, currentOwner) => {
-      resultObj[currentOwner.display_name] = currentOwner as User;
+      resultObj[currentOwner.user_id] = currentOwner as User;
       return resultObj;
     },
     {}


### PR DESCRIPTION
### Summary of Changes

For now we are passing the User Display Name to apply certain operations on the data owner. 
Since we are using the same model as the User for the Data Owner, it should be the user_id for those operations. 


### Tests

NA

### Documentation

NA

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
