### PR TITLE
fix: Uneditable descriptions with no value or possible actions should not show header

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -124,133 +124,137 @@ describe('ColumnListItem', () => {
       expect(wrapper.find('.column-dropdown').exists()).toBe(false);
     });
 
-    it('renders column stats and editable text when expanded', () => {
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find('.expanded-content').exists()).toBe(true);
-      expect(newWrapper.find(ColumnDescEditableText).exists()).toBe(true);
-      expect(newWrapper.find(ColumnStats).exists()).toBe(true);
-    });
-
-    it('renders EditableSection with correct description, edit text and Url when expanded', () => {
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find(EditableSection).exists()).toBe(true);
-      const editableSection = newWrapper.find(EditableSection);
-      expect(editableSection.props()).toMatchObject({
-        title: 'Description',
-        readOnly: !props.data.is_editable,
-        editText: props.editText,
-        editUrl: props.editUrl,
+    describe('when expanded', () => {
+      it('renders column stats and editable text when expanded', () => {
+        instance.setState({ isExpanded: true });
+        const newWrapper = shallow(instance.render());
+        expect(newWrapper.find('.expanded-content').exists()).toBe(true);
+        expect(newWrapper.find(EditableSection).exists()).toBe(true);
+        expect(newWrapper.find(ColumnDescEditableText).exists()).toBe(true);
+        expect(newWrapper.find(ColumnStats).exists()).toBe(true);
       });
-    });
 
-    it('renders EditableSection with non-empty description, empty edit text and url for editable column description when expanded', () => {
-      const { props, wrapper } = setup({
-        editText: '',
-        editUrl: '',
+      it('renders EditableSection with non-empty description, edit text and url when expanded', () => {
+        instance.setState({ isExpanded: true });
+        const newWrapper = shallow(instance.render());
+        const editableSection = newWrapper.find(EditableSection);
+        expect(editableSection.props()).toMatchObject({
+          title: 'Description',
+          readOnly: !props.data.is_editable,
+          editText: props.editText,
+          editUrl: props.editUrl,
+        });
       });
-      const instance = wrapper.instance();
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find(EditableSection).exists()).toBe(true);
-      const editableSection = newWrapper.find(EditableSection);
-      expect(editableSection.props()).toMatchObject({
-        title: 'Description',
-        readOnly: !props.data.is_editable,
-        editText: props.editText,
-        editUrl: props.editUrl,
-      });
-    });
 
-    it('renders EditableSection with empty description, edit text and url for editable column description when expanded', () => {
-      const { props, wrapper } = setup({
-        data: {
-          name: 'test_column_name',
-          description: '',
-          is_editable: true,
-          col_type: 'varchar(32)',
-          stats: [
-            {
-              end_epoch: 1571616000,
-              start_epoch: 1571616000,
-              stat_type: 'count',
-              stat_val: '12345',
+      it('renders EditableSection with non-empty description, empty edit text and url when expanded', () => {
+        const { props, wrapper } = setup({
+          editText: '',
+          editUrl: '',
+        });
+        const instance = wrapper.instance();
+        instance.setState({ isExpanded: true });
+        const newWrapper = shallow(instance.render());
+        expect(newWrapper.find(EditableSection).exists()).toBe(true);
+        const editableSection = newWrapper.find(EditableSection);
+        expect(editableSection.props()).toMatchObject({
+          title: 'Description',
+          readOnly: !props.data.is_editable,
+          editText: props.editText,
+          editUrl: props.editUrl,
+        });
+      });
+
+      describe('when empty description', () => {
+        it('renders EditableSection with empty edit text and url for editable column description when expanded', () => {
+          const { props, wrapper } = setup({
+            data: {
+              name: 'test_column_name',
+              description: '',
+              is_editable: true,
+              col_type: 'varchar(32)',
+              stats: [
+                {
+                  end_epoch: 1571616000,
+                  start_epoch: 1571616000,
+                  stat_type: 'count',
+                  stat_val: '12345',
+                },
+              ],
             },
-          ],
-        },
-        editText: '',
-        editUrl: '',
-      });
-      const instance = wrapper.instance();
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find(EditableSection).exists()).toBe(true);
-      const editableSection = newWrapper.find(EditableSection);
-      expect(editableSection.props()).toMatchObject({
-        title: 'Description',
-        readOnly: !props.data.is_editable,
-        editText: props.editText,
-        editUrl: props.editUrl,
-      });
-    });
+            editText: '',
+            editUrl: '',
+          });
+          const instance = wrapper.instance();
+          instance.setState({ isExpanded: true });
+          const newWrapper = shallow(instance.render());
+          expect(newWrapper.find(EditableSection).exists()).toBe(true);
+          const editableSection = newWrapper.find(EditableSection);
+          expect(editableSection.props()).toMatchObject({
+            title: 'Description',
+            readOnly: !props.data.is_editable,
+            editText: props.editText,
+            editUrl: props.editUrl,
+          });
+        });
 
-    it('does not render EditableSection with empty description, edit text and url for non-editable column description when expanded', () => {
-      const { wrapper } = setup({
-        data: {
-          name: 'test_column_name',
-          description: '',
-          is_editable: false,
-          col_type: 'varchar(32)',
-          stats: [
-            {
-              end_epoch: 1571616000,
-              start_epoch: 1571616000,
-              stat_type: 'count',
-              stat_val: '12345',
+        it('does not render EditableSection with empty edit text and url for non-editable column description when expanded', () => {
+          const { wrapper } = setup({
+            data: {
+              name: 'test_column_name',
+              description: '',
+              is_editable: false,
+              col_type: 'varchar(32)',
+              stats: [
+                {
+                  end_epoch: 1571616000,
+                  start_epoch: 1571616000,
+                  stat_type: 'count',
+                  stat_val: '12345',
+                },
+              ],
             },
-          ],
-        },
-        editText: '',
-        editUrl: '',
-      });
-      const instance = wrapper.instance();
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find(EditableSection).exists()).toBe(false);
-    });
-    it('renders EditableSection with empty description, non-empty edit text and url for non-editable column description when expanded', () => {
-      const { props, wrapper } = setup({
-        data: {
-          name: 'test_column_name',
-          description: '',
-          is_editable: false,
-          col_type: 'varchar(32)',
-          stats: [
-            {
-              end_epoch: 1571616000,
-              start_epoch: 1571616000,
-              stat_type: 'count',
-              stat_val: '12345',
-            },
-          ],
-        },
-        editText: 'Click to edit description in source',
-        editUrl: 'source/test_column_name',
-      });
-      const instance = wrapper.instance();
-      instance.setState({ isExpanded: true });
-      const newWrapper = shallow(instance.render());
-      expect(newWrapper.find(EditableSection).exists()).toBe(true);
-      const editableSection = newWrapper.find(EditableSection);
-      expect(editableSection.props()).toMatchObject({
-        title: 'Description',
-        readOnly: !props.data.is_editable,
-        editText: props.editText,
-        editUrl: props.editUrl,
-      });
-    });
+            editText: '',
+            editUrl: '',
+          });
+          const instance = wrapper.instance();
+          instance.setState({ isExpanded: true });
+          const newWrapper = shallow(instance.render());
+          expect(newWrapper.find(EditableSection).exists()).toBe(false);
+        });
 
+        it('renders EditableSection with non-empty edit text and url for non-editable column description when expanded', () => {
+          const { props, wrapper } = setup({
+            data: {
+              name: 'test_column_name',
+              description: '',
+              is_editable: false,
+              col_type: 'varchar(32)',
+              stats: [
+                {
+                  end_epoch: 1571616000,
+                  start_epoch: 1571616000,
+                  stat_type: 'count',
+                  stat_val: '12345',
+                },
+              ],
+            },
+            editText: 'Click to edit description in source',
+            editUrl: 'source/test_column_name',
+          });
+          const instance = wrapper.instance();
+          instance.setState({ isExpanded: true });
+          const newWrapper = shallow(instance.render());
+          expect(newWrapper.find(EditableSection).exists()).toBe(true);
+          const editableSection = newWrapper.find(EditableSection);
+          expect(editableSection.props()).toMatchObject({
+            title: 'Description',
+            readOnly: !props.data.is_editable,
+            editText: props.editText,
+            editUrl: props.editUrl,
+          });
+        });
+      });
+    });
     describe('when not expanded', () => {
       let newWrapper;
       beforeAll(() => {

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -132,7 +132,81 @@ describe('ColumnListItem', () => {
       expect(newWrapper.find(ColumnStats).exists()).toBe(true);
     });
 
-    it('renders EditableSection with correct edit text and Url when expanded', () => {
+    it('renders EditableSection with correct description, edit text and Url when expanded', () => {
+      instance.setState({ isExpanded: true });
+      const newWrapper = shallow(instance.render());
+      expect(newWrapper.find(EditableSection).exists()).toBe(true);
+      const editableSection = newWrapper.find(EditableSection);
+      expect(editableSection.props()).toMatchObject({
+        title: 'Description',
+        readOnly: !props.data.is_editable,
+        editText: props.editText,
+        editUrl: props.editUrl,
+      });
+    });
+
+    it('renders EditableSection with description and empty editText and editUrl when expanded', () => {
+      const { props, wrapper } = setup({
+        editText: '',
+        editUrl: '',
+      });
+      const instance = wrapper.instance();
+      instance.setState({ isExpanded: true });
+      const newWrapper = shallow(instance.render());
+      expect(newWrapper.find(EditableSection).exists()).toBe(true);
+      const editableSection = newWrapper.find(EditableSection);
+      expect(editableSection.props()).toMatchObject({
+        title: 'Description',
+        readOnly: !props.data.is_editable,
+        editText: props.editText,
+        editUrl: props.editUrl,
+      });
+    });
+
+    it('does not renders EditableSection with empty description, editText and editUrl when expanded', () => {
+      const { wrapper } = setup({
+        data: {
+          name: 'test_column_name',
+          description: '',
+          is_editable: true,
+          col_type: 'varchar(32)',
+          stats: [
+            {
+              end_epoch: 1571616000,
+              start_epoch: 1571616000,
+              stat_type: 'count',
+              stat_val: '12345',
+            },
+          ],
+        },
+        editText: '',
+        editUrl: '',
+      });
+      const instance = wrapper.instance();
+      instance.setState({ isExpanded: true });
+      const newWrapper = shallow(instance.render());
+      expect(newWrapper.find(EditableSection).exists()).toBe(false);
+    });
+    it('renders EditableSection with empty description,but non-empty editText and editUrl when expanded', () => {
+      const { props, wrapper } = setup({
+        data: {
+          name: 'test_column_name',
+          description: '',
+          is_editable: true,
+          col_type: 'varchar(32)',
+          stats: [
+            {
+              end_epoch: 1571616000,
+              start_epoch: 1571616000,
+              stat_type: 'count',
+              stat_val: '12345',
+            },
+          ],
+        },
+        editText: 'Click to edit discription in source',
+        editUrl: 'source/test_column_name',
+      });
+      const instance = wrapper.instance();
       instance.setState({ isExpanded: true });
       const newWrapper = shallow(instance.render());
       expect(newWrapper.find(EditableSection).exists()).toBe(true);

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -163,7 +163,7 @@ describe('ColumnListItem', () => {
       });
     });
 
-    it('renders EditableSection with empty description, editText and editUrl for editable column description when expanded', () => {
+    it('renders EditableSection with empty description, edit text and url for editable column description when expanded', () => {
       const { props, wrapper } = setup({
         data: {
           name: 'test_column_name',
@@ -195,7 +195,7 @@ describe('ColumnListItem', () => {
       });
     });
 
-    it('does not renders EditableSection with empty description, editText and editUrl for non-editable column description when expanded', () => {
+    it('does not render EditableSection with empty description, edit text and url for non-editable column description when expanded', () => {
       const { wrapper } = setup({
         data: {
           name: 'test_column_name',
@@ -219,7 +219,7 @@ describe('ColumnListItem', () => {
       const newWrapper = shallow(instance.render());
       expect(newWrapper.find(EditableSection).exists()).toBe(false);
     });
-    it('renders EditableSection with empty description,but non-empty editText and editUrl for non-editable column description when expanded', () => {
+    it('renders EditableSection with empty description, non-empty edit text and url for non-editable column description when expanded', () => {
       const { props, wrapper } = setup({
         data: {
           name: 'test_column_name',

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -68,9 +68,9 @@ describe('ColumnListItem', () => {
 
     it('turns expanded state to the opposite state', () => {
       setStateSpy.mockClear();
-      const { isExpanded } = instance.state;
+      const prevState = instance.state;
       instance.toggleExpand(null);
-      expect(setStateSpy).toHaveBeenCalledWith({ isExpanded: !isExpanded });
+      expect(setStateSpy).toHaveBeenCalled();
     });
   });
 
@@ -125,7 +125,7 @@ describe('ColumnListItem', () => {
     });
 
     describe('when expanded', () => {
-      it('renders column stats and editable text when expanded', () => {
+      it('renders column stats and editable text', () => {
         instance.setState({ isExpanded: true });
         const newWrapper = shallow(instance.render());
         expect(newWrapper.find('.expanded-content').exists()).toBe(true);
@@ -134,7 +134,7 @@ describe('ColumnListItem', () => {
         expect(newWrapper.find(ColumnStats).exists()).toBe(true);
       });
 
-      it('renders EditableSection with non-empty description, edit text and url when expanded', () => {
+      it('renders EditableSection with non-empty description, edit text and url', () => {
         instance.setState({ isExpanded: true });
         const newWrapper = shallow(instance.render());
         const editableSection = newWrapper.find(EditableSection);
@@ -146,7 +146,7 @@ describe('ColumnListItem', () => {
         });
       });
 
-      it('renders EditableSection with non-empty description, empty edit text and url when expanded', () => {
+      it('renders EditableSection with non-empty description, empty edit text and url', () => {
         const { props, wrapper } = setup({
           editText: '',
           editUrl: '',
@@ -165,7 +165,7 @@ describe('ColumnListItem', () => {
       });
 
       describe('when empty description', () => {
-        it('renders EditableSection with empty edit text and url for editable column description when expanded', () => {
+        it('renders EditableSection with empty edit text and url for editable column description', () => {
           const { props, wrapper } = setup({
             data: {
               name: 'test_column_name',
@@ -197,7 +197,7 @@ describe('ColumnListItem', () => {
           });
         });
 
-        it('does not render EditableSection with empty edit text and url for non-editable column description when expanded', () => {
+        it('does not render EditableSection with empty edit text and url for non-editable column description', () => {
           const { wrapper } = setup({
             data: {
               name: 'test_column_name',
@@ -222,7 +222,7 @@ describe('ColumnListItem', () => {
           expect(newWrapper.find(EditableSection).exists()).toBe(false);
         });
 
-        it('renders EditableSection with non-empty edit text and url for non-editable column description when expanded', () => {
+        it('renders EditableSection with non-empty edit text and url for non-editable column description', () => {
           const { props, wrapper } = setup({
             data: {
               name: 'test_column_name',

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.spec.tsx
@@ -145,7 +145,7 @@ describe('ColumnListItem', () => {
       });
     });
 
-    it('renders EditableSection with description and empty editText and editUrl when expanded', () => {
+    it('renders EditableSection with non-empty description, empty edit text and url for editable column description when expanded', () => {
       const { props, wrapper } = setup({
         editText: '',
         editUrl: '',
@@ -163,12 +163,44 @@ describe('ColumnListItem', () => {
       });
     });
 
-    it('does not renders EditableSection with empty description, editText and editUrl when expanded', () => {
-      const { wrapper } = setup({
+    it('renders EditableSection with empty description, editText and editUrl for editable column description when expanded', () => {
+      const { props, wrapper } = setup({
         data: {
           name: 'test_column_name',
           description: '',
           is_editable: true,
+          col_type: 'varchar(32)',
+          stats: [
+            {
+              end_epoch: 1571616000,
+              start_epoch: 1571616000,
+              stat_type: 'count',
+              stat_val: '12345',
+            },
+          ],
+        },
+        editText: '',
+        editUrl: '',
+      });
+      const instance = wrapper.instance();
+      instance.setState({ isExpanded: true });
+      const newWrapper = shallow(instance.render());
+      expect(newWrapper.find(EditableSection).exists()).toBe(true);
+      const editableSection = newWrapper.find(EditableSection);
+      expect(editableSection.props()).toMatchObject({
+        title: 'Description',
+        readOnly: !props.data.is_editable,
+        editText: props.editText,
+        editUrl: props.editUrl,
+      });
+    });
+
+    it('does not renders EditableSection with empty description, editText and editUrl for non-editable column description when expanded', () => {
+      const { wrapper } = setup({
+        data: {
+          name: 'test_column_name',
+          description: '',
+          is_editable: false,
           col_type: 'varchar(32)',
           stats: [
             {
@@ -187,12 +219,12 @@ describe('ColumnListItem', () => {
       const newWrapper = shallow(instance.render());
       expect(newWrapper.find(EditableSection).exists()).toBe(false);
     });
-    it('renders EditableSection with empty description,but non-empty editText and editUrl when expanded', () => {
+    it('renders EditableSection with empty description,but non-empty editText and editUrl for non-editable column description when expanded', () => {
       const { props, wrapper } = setup({
         data: {
           name: 'test_column_name',
           description: '',
-          is_editable: true,
+          is_editable: false,
           col_type: 'varchar(32)',
           stats: [
             {
@@ -203,7 +235,7 @@ describe('ColumnListItem', () => {
             },
           ],
         },
-        editText: 'Click to edit discription in source',
+        editText: 'Click to edit description in source',
         editUrl: 'source/test_column_name',
       });
       const instance = wrapper.instance();

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -59,7 +59,10 @@ export class ColumnListItem extends React.Component<
         label: `${metadata.name} ${metadata.col_type}`,
       });
     }
-    this.setState({ isExpanded: !this.state.isExpanded });
+    if (this.shouldRenderDescription() || this.props.data.stats.length !== 0) {
+      this.setState({ isExpanded: !this.state.isExpanded });
+    }
+    // this.setState({ isExpanded: !this.state.isExpanded });
   };
 
   openRequest = () => {
@@ -78,7 +81,7 @@ export class ColumnListItem extends React.Component<
     if (data.description) {
       return true;
     }
-    if (!editText && !editUrl) {
+    if (!editText && !editUrl && !data.is_editable) {
       return false;
     }
     return true;

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -74,16 +74,14 @@ export class ColumnListItem extends React.Component<
   };
 
   renderDescription = () => {
-    let expand: boolean = true;
-    if (
-      typeof this.props.data.description != 'undefined' &&
-      this.props.data.description
-    ) {
-      expand = true;
-    } else if (this.props.editText === '' && this.props.editUrl === '') {
-      expand = false;
+    const { data, editText, editUrl } = this.props;
+    if (data.description) {
+      return true;
     }
-    return expand;
+    if (!editText && !editUrl) {
+      return false;
+    }
+    return true;
   };
 
   renderColumnType = (columnIndex: number, type: string) => {

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -18,6 +18,7 @@ import './styles.scss';
 import EditableSection from 'components/common/EditableSection';
 
 const MORE_BUTTON_TEXT = 'More options';
+const EDITABLE_SECTION_TITLE = 'Description';
 
 interface DispatchFromProps {
   openRequestDescriptionDialog: (
@@ -51,15 +52,15 @@ export class ColumnListItem extends React.Component<
   }
 
   toggleExpand = (e) => {
+    const metadata = this.props.data;
     if (!this.state.isExpanded) {
-      const metadata = this.props.data;
       logClick(e, {
         target_id: `column::${metadata.name}`,
         target_type: 'column stats',
         label: `${metadata.name} ${metadata.col_type}`,
       });
     }
-    if (this.shouldRenderDescription() || this.props.data.stats.length !== 0) {
+    if (this.shouldRenderDescription() || metadata.stats.length !== 0) {
       this.setState({ isExpanded: !this.state.isExpanded });
     }
   };
@@ -187,7 +188,7 @@ export class ColumnListItem extends React.Component<
               <div className="stop-propagation" onClick={this.stopPropagation}>
                 {this.shouldRenderDescription() && (
                   <EditableSection
-                    title="Description"
+                    title={EDITABLE_SECTION_TITLE}
                     readOnly={!metadata.is_editable}
                     editText={this.props.editText}
                     editUrl={this.props.editUrl}

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -73,6 +73,19 @@ export class ColumnListItem extends React.Component<
     e.stopPropagation();
   };
 
+  renderDescription = () => {
+    let expand: boolean = true;
+    if (
+      typeof this.props.data.description != 'undefined' &&
+      this.props.data.description
+    ) {
+      expand = true;
+    } else if (this.props.editText === '' && this.props.editUrl === '') {
+      expand = false;
+    }
+    return expand;
+  };
+
   renderColumnType = (columnIndex: number, type: string) => {
     const truncatedTypes: string[] = ['array', 'struct', 'map', 'row'];
     let shouldTrucate = false;
@@ -172,19 +185,21 @@ export class ColumnListItem extends React.Component<
           {this.state.isExpanded && (
             <section className="expanded-content">
               <div className="stop-propagation" onClick={this.stopPropagation}>
-                <EditableSection
-                  title="Description"
-                  readOnly={!metadata.is_editable}
-                  editText={this.props.editText}
-                  editUrl={this.props.editUrl}
-                >
-                  <ColumnDescEditableText
-                    columnIndex={this.props.index}
-                    editable={metadata.is_editable}
-                    maxLength={getMaxLength('columnDescLength')}
-                    value={metadata.description}
-                  />
-                </EditableSection>
+                {this.renderDescription() && (
+                  <EditableSection
+                    title="Description"
+                    readOnly={!metadata.is_editable}
+                    editText={this.props.editText}
+                    editUrl={this.props.editUrl}
+                  >
+                    <ColumnDescEditableText
+                      columnIndex={this.props.index}
+                      editable={metadata.is_editable}
+                      maxLength={getMaxLength('columnDescLength')}
+                      value={metadata.description}
+                    />
+                  </EditableSection>
+                )}
               </div>
               <ColumnStats stats={metadata.stats} />
             </section>

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -61,7 +61,9 @@ export class ColumnListItem extends React.Component<
       });
     }
     if (this.shouldRenderDescription() || metadata.stats.length !== 0) {
-      this.setState({ isExpanded: !this.state.isExpanded });
+      this.setState((prevState) => ({
+        isExpanded: !prevState.isExpanded,
+      }));
     }
   };
 

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -73,7 +73,7 @@ export class ColumnListItem extends React.Component<
     e.stopPropagation();
   };
 
-  renderDescription = () => {
+  shouldRenderDescription = (): boolean => {
     const { data, editText, editUrl } = this.props;
     if (data.description) {
       return true;
@@ -183,7 +183,7 @@ export class ColumnListItem extends React.Component<
           {this.state.isExpanded && (
             <section className="expanded-content">
               <div className="stop-propagation" onClick={this.stopPropagation}>
-                {this.renderDescription() && (
+                {this.shouldRenderDescription() && (
                   <EditableSection
                     title="Description"
                     readOnly={!metadata.is_editable}

--- a/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnListItem/index.tsx
@@ -62,7 +62,6 @@ export class ColumnListItem extends React.Component<
     if (this.shouldRenderDescription() || this.props.data.stats.length !== 0) {
       this.setState({ isExpanded: !this.state.isExpanded });
     }
-    // this.setState({ isExpanded: !this.state.isExpanded });
   };
 
   openRequest = () => {


### PR DESCRIPTION
### Summary of Changes

For un-editable column descriptions that have no value and have no edit url, our current UI shows the `Description` header when the column is expanded. However there is nothing to show here and nothing the user will ever be able to interact with (e.g. no click to edit in url and no `Add Description`). As a result, we shouldn't show the header.

### Tests
Will be adding tests

### Documentation

NA

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
