### PR TITLE
build: use static CSS and JS filenames in dev

### DIFF
--- a/amundsen_application/static/webpack.common.ts
+++ b/amundsen_application/static/webpack.common.ts
@@ -100,11 +100,7 @@ const config: webpack.Configuration = {
   plugins: [
     new CleanWebpackPlugin(),
     new MomentLocalesPlugin(), // To strip all locales except “en”
-    new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css',
-    }),
     ...htmlWebpackPluginConfig,
-    // new BundleAnalyzerPlugin(),   // Uncomment to analyze the production bundle on local
   ],
   optimization: {
     moduleIds: 'hashed',

--- a/amundsen_application/static/webpack.dev.ts
+++ b/amundsen_application/static/webpack.dev.ts
@@ -1,4 +1,5 @@
 import merge from 'webpack-merge';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 // import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 import commonConfig from './webpack.common';
@@ -7,6 +8,12 @@ export default merge(commonConfig, {
   mode: 'development',
   devtool: 'inline-source-map',
   plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].dev.css',
+    }),
     // new BundleAnalyzerPlugin()     // Uncomment to check the bundle size on dev
   ],
+  output: {
+    filename: '[name].dev.js',
+  },
 });

--- a/amundsen_application/static/webpack.prod.ts
+++ b/amundsen_application/static/webpack.prod.ts
@@ -1,3 +1,4 @@
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import merge from 'webpack-merge';
 import TerserPlugin from 'terser-webpack-plugin';
 import commonConfig from './webpack.common';
@@ -14,4 +15,9 @@ export default merge(commonConfig, {
       }),
     ],
   },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].[contenthash].css',
+    }),
+  ],
 });


### PR DESCRIPTION
In production, it's helpful to use content addressing to guarantee cache busting
when publishing changes.

However, in development, because the server serves a static copy of the
index.html, that means that changing the Javascript bundle or CSS requires an
otherwise-unnecessary restart of the server.

This change makes the CSS and JS assets use fixed filenames so that a server
restart isn't needed.

Downside of this approach is there's now a dev/prod disparity and the config is
more spread out between files. The positive is we don't need to modify the
semantics of the server at all.

### Summary of Changes



### Tests

AFAICT, there are no selenium-style integration tests, so I'm not aware of an established pattern to test this behavior. Happy to add tests if there's a pathway, though!

### Documentation

The docs don't mention this stuff right now, so this should mean we don't need to change the docs.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
