### PR TITLE
fix: DashboardPage Flag usage; Markdown to render HTML

### DIFF
--- a/amundsen_application/static/js/components/DashboardPage/index.spec.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.spec.tsx
@@ -18,6 +18,7 @@ import { dashboardMetadata } from 'fixtures/metadata/dashboard';
 import { NO_TIMESTAMP_TEXT } from 'components/constants';
 import * as LogUtils from 'utils/logUtils';
 import { ResourceType } from 'interfaces';
+import { BadgeStyle } from 'config/config-types';
 import ChartList from './ChartList';
 import ImagePreview from './ImagePreview';
 
@@ -146,15 +147,15 @@ describe('DashboardPage', () => {
       ({ wrapper } = setup());
     });
 
-    it('returns success if status === LAST_RUN_SUCCEEDED', () => {
+    it('returns BadgeStyle.SUCCESS if status === LAST_RUN_SUCCEEDED', () => {
       expect(
         wrapper.instance().mapStatusToStyle(Constants.LAST_RUN_SUCCEEDED)
-      ).toBe('success');
+      ).toBe(BadgeStyle.SUCCESS);
     });
 
-    it('returns danger if status !== LAST_RUN_SUCCEEDED', () => {
+    it('returns BadgeStyle.DANGER if status !== LAST_RUN_SUCCEEDED', () => {
       expect(wrapper.instance().mapStatusToStyle('anythingelse')).toBe(
-        'danger'
+        BadgeStyle.DANGER
       );
     });
   });
@@ -226,9 +227,10 @@ describe('DashboardPage', () => {
     });
 
     it('renders a Flag for last run state', () => {
+      const mockStyle = BadgeStyle.DANGER;
       const mapStatusToStyleSpy = jest
         .spyOn(wrapper.instance(), 'mapStatusToStyle')
-        .mockImplementationOnce(() => 'testStyle');
+        .mockImplementationOnce(() => mockStyle);
       wrapper.instance().forceUpdate();
       const element = wrapper.find('.last-run-state').find(Flag);
 
@@ -236,7 +238,7 @@ describe('DashboardPage', () => {
       expect(mapStatusToStyleSpy).toHaveBeenCalledWith(
         props.dashboard.last_run_state
       );
-      expect(element.props().labelStyle).toBe('testStyle');
+      expect(element.props().labelStyle).toBe(mockStyle);
     });
 
     it('renders an ImagePreview with correct props', () => {

--- a/amundsen_application/static/js/components/DashboardPage/index.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/index.tsx
@@ -39,6 +39,7 @@ import TagInput from 'components/Tags/TagInput';
 import { ResourceType } from 'interfaces';
 
 import { getSourceDisplayName, getSourceIconClass } from 'config/config-utils';
+import { BadgeStyle } from 'config/config-types';
 
 import { getLoggingParams } from 'utils/logUtils';
 
@@ -46,9 +47,6 @@ import { NO_TIMESTAMP_TEXT } from 'components/constants';
 import ImagePreview from './ImagePreview';
 
 import './styles.scss';
-
-const STATUS_SUCCESS = 'success';
-const STATUS_DANGER = 'danger';
 
 interface DashboardPageState {
   uri: string;
@@ -105,11 +103,11 @@ export class DashboardPage extends React.Component<
     }
   }
 
-  mapStatusToStyle = (status: string): string => {
+  mapStatusToStyle = (status: string): BadgeStyle => {
     if (status === LAST_RUN_SUCCEEDED) {
-      return STATUS_SUCCESS;
+      return BadgeStyle.SUCCESS;
     }
-    return STATUS_DANGER;
+    return BadgeStyle.DANGER;
   };
 
   renderTabs() {

--- a/amundsen_application/static/js/components/common/EditableText/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableText/index.tsx
@@ -52,7 +52,6 @@ class EditableText extends React.Component<
 
   public static defaultProps: EditableTextProps = {
     editable: true,
-    isEditing: false,
     maxLength: 250,
     onSubmitValue: null,
     getLatestValue: null,

--- a/amundsen_application/static/js/components/common/EditableText/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableText/index.tsx
@@ -52,6 +52,7 @@ class EditableText extends React.Component<
 
   public static defaultProps: EditableTextProps = {
     editable: true,
+    isEditing: false,
     maxLength: 250,
     onSubmitValue: null,
     getLatestValue: null,
@@ -120,11 +121,13 @@ class EditableText extends React.Component<
   };
 
   render() {
+    console.log(this.state.value)
+    console.log(this.props)
     if (!this.props.isEditing) {
       return (
         <div className="editable-text">
           <div className="markdown-wrapper">
-            <ReactMarkdown source={this.state.value} />
+            <ReactMarkdown source={this.state.value} escapeHtml={false} />
           </div>
           {this.props.editable && !this.state.value && (
             <a

--- a/amundsen_application/static/js/components/common/EditableText/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableText/index.tsx
@@ -121,8 +121,6 @@ class EditableText extends React.Component<
   };
 
   render() {
-    console.log(this.state.value)
-    console.log(this.props)
     if (!this.props.isEditing) {
       return (
         <div className="editable-text">

--- a/amundsen_application/static/js/components/common/Flag/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.spec.tsx
@@ -5,8 +5,8 @@ import * as React from 'react';
 
 import { shallow } from 'enzyme';
 
-import Flag, { CaseType, FlagProps, convertText } from '.';
 import { BadgeStyle } from 'config/config-types';
+import Flag, { CaseType, FlagProps, convertText } from '.';
 
 describe('Flag', () => {
   let props: FlagProps;

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -16,7 +16,7 @@ export enum CaseType {
 export interface FlagProps {
   caseType?: string | null;
   text: string;
-  labelStyle?: string;
+  labelStyle?: BadgeStyle;
 }
 
 export function convertText(str: string, caseType: string): string {

--- a/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/UserListItem/index.spec.tsx
@@ -10,9 +10,8 @@ import Flag from 'components/common/Flag';
 import { Link } from 'react-router-dom';
 
 import { ResourceType } from 'interfaces';
-import UserListItem, { UserListItemProps } from '.';
-
 import { BadgeStyle } from 'config/config-types';
+import UserListItem, { UserListItemProps } from '.';
 
 describe('UserListItem', () => {
   const setup = (propOverrides?: Partial<UserListItemProps>) => {


### PR DESCRIPTION
### Summary of Changes

This PR fixes two issues:
1. `Flag` usage on `DashboardPage` should have referenced existing `BadgeStyle` enums vs. hardcoding duplicate text.
2. Leverage `escapeHtml={false}` on `ReactMarkdown` for our description component. This attribute needs to be set to allow rendering of useful html such as `<img>` tags
3. Other changes come from running lint-fix.

### Tests

N/A, no functionality has been changed

### Documentation

N/A, no functionality has been changed

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
