### PR TITLE
chore: Deprecates React.SFC

### DIFF
--- a/amundsen_application/static/js/components/DashboardPage/QueryListItem/CodeBlock.tsx
+++ b/amundsen_application/static/js/components/DashboardPage/QueryListItem/CodeBlock.tsx
@@ -10,7 +10,7 @@ type CodeBlockProps = {
   text: string;
 };
 
-const CodeBlock: React.SFC<CodeBlockProps> = ({ text }: CodeBlockProps) => {
+const CodeBlock: React.FC<CodeBlockProps> = ({ text }: CodeBlockProps) => {
   return (
     <CopyBlock
       text={text}

--- a/amundsen_application/static/js/components/Feedback/index.tsx
+++ b/amundsen_application/static/js/components/Feedback/index.tsx
@@ -14,12 +14,12 @@ import * as Constants from './constants';
 import './styles.scss';
 
 export interface FeedbackProps {
-  content?: React.SFC<any>;
+  content?: React.FC<any>;
   title?: string;
 }
 
 interface FeedbackState {
-  content: React.SFC<any>;
+  content: React.FC<any>;
   feedbackType: FeedbackType;
   isOpen: boolean;
 }

--- a/amundsen_application/static/js/components/NotFoundPage/index.tsx
+++ b/amundsen_application/static/js/components/NotFoundPage/index.tsx
@@ -9,7 +9,7 @@ import './styles.scss';
 
 import Breadcrumb from 'components/common/Breadcrumb';
 
-const NotFoundPage: React.SFC<any> = () => {
+const NotFoundPage: React.FC<any> = () => {
   return (
     <DocumentTitle title="404 Page Not Found - Amundsen">
       <div className="container not-found-page">

--- a/amundsen_application/static/js/components/SearchPage/SearchPanel/index.tsx
+++ b/amundsen_application/static/js/components/SearchPage/SearchPanel/index.tsx
@@ -9,7 +9,7 @@ type SearchPanelProps = {
   children: React.ReactNode;
 };
 
-const SearchPanel: React.SFC = ({ children }: SearchPanelProps) => {
+const SearchPanel: React.FC = ({ children }: SearchPanelProps) => {
   return (
     <aside className="search-control-panel">
       {React.Children.map(children, (child, index) => {

--- a/amundsen_application/static/js/components/TableDetail/ColumnList/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ColumnList/index.tsx
@@ -13,7 +13,7 @@ interface ColumnListProps {
   editUrl?: string;
 }
 
-const ColumnList: React.SFC<ColumnListProps> = ({
+const ColumnList: React.FC<ColumnListProps> = ({
   columns,
   editText,
   editUrl,

--- a/amundsen_application/static/js/components/TableDetail/FrequentUsers/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/FrequentUsers/index.tsx
@@ -56,7 +56,7 @@ export function renderReader(
   );
 }
 
-const FrequentUsers: React.SFC<FrequentUsersProps> = ({
+const FrequentUsers: React.FC<FrequentUsersProps> = ({
   readers,
 }: FrequentUsersProps) => {
   if (readers.length === 0) {

--- a/amundsen_application/static/js/components/TableDetail/LineageLink/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/LineageLink/index.tsx
@@ -12,7 +12,7 @@ export interface LineageLinkProps {
   tableData: TableMetadata;
 }
 
-const LineageLink: React.SFC<LineageLinkProps> = ({
+const LineageLink: React.FC<LineageLinkProps> = ({
   tableData,
 }: LineageLinkProps) => {
   const config = AppConfig.tableLineage;

--- a/amundsen_application/static/js/components/TableDetail/ResourceReportsDropdown/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/ResourceReportsDropdown/index.tsx
@@ -7,7 +7,7 @@ export interface ResourceReportProps {
   resourceReports: ResourceReport[];
 }
 
-const TableReportsDropdown: React.SFC<ResourceReportProps> = ({
+const TableReportsDropdown: React.FC<ResourceReportProps> = ({
   resourceReports,
 }: ResourceReportProps) => {
   if (resourceReports === null || resourceReports.length < 1) return null;

--- a/amundsen_application/static/js/components/TableDetail/SourceLink/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/SourceLink/index.tsx
@@ -11,7 +11,7 @@ export interface SourceLinkProps {
   tableSource: TableSource;
 }
 
-const SourceLink: React.SFC<SourceLinkProps> = ({
+const SourceLink: React.FC<SourceLinkProps> = ({
   tableSource,
 }: SourceLinkProps) => {
   if (tableSource === null || tableSource.source === null) return null;

--- a/amundsen_application/static/js/components/TableDetail/TableHeaderBullets/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/TableHeaderBullets/index.tsx
@@ -15,7 +15,7 @@ export interface TableHeaderBulletsProps {
   database: string;
 }
 
-const TableHeaderBullets: React.SFC<TableHeaderBulletsProps> = ({
+const TableHeaderBullets: React.FC<TableHeaderBulletsProps> = ({
   cluster,
   database,
 }: TableHeaderBulletsProps) => {

--- a/amundsen_application/static/js/components/TableDetail/WriterLink/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/WriterLink/index.tsx
@@ -12,7 +12,7 @@ export interface WriterLinkProps {
   tableWriter: TableWriter;
 }
 
-const WriterLink: React.SFC<WriterLinkProps> = ({
+const WriterLink: React.FC<WriterLinkProps> = ({
   tableWriter,
 }: WriterLinkProps) => {
   if (tableWriter === null || tableWriter.application_url === null) {

--- a/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
+++ b/amundsen_application/static/js/components/common/AvatarLabel/index.tsx
@@ -14,7 +14,7 @@ export interface AvatarLabelProps {
   src?: string;
 }
 
-const AvatarLabel: React.SFC<AvatarLabelProps> = ({
+const AvatarLabel: React.FC<AvatarLabelProps> = ({
   avatarClass,
   labelClass,
   label,

--- a/amundsen_application/static/js/components/common/BadgeList/index.tsx
+++ b/amundsen_application/static/js/components/common/BadgeList/index.tsx
@@ -11,7 +11,7 @@ export interface BadgeListProps {
   badges: Badge[];
 }
 
-const BadgeList: React.SFC<BadgeListProps> = ({ badges }: BadgeListProps) => {
+const BadgeList: React.FC<BadgeListProps> = ({ badges }: BadgeListProps) => {
   return (
     <span className="badge-list">
       {badges.map((badge, index) => {

--- a/amundsen_application/static/js/components/common/Breadcrumb/index.tsx
+++ b/amundsen_application/static/js/components/common/Breadcrumb/index.tsx
@@ -24,7 +24,7 @@ type BreadcrumbDirection = 'left' | 'right';
 
 export type BreadcrumbProps = OwnProps & MapDispatchToProps;
 
-export const Breadcrumb: React.SFC<BreadcrumbProps> = (
+export const Breadcrumb: React.FC<BreadcrumbProps> = (
   props: BreadcrumbProps
 ) => {
   const { direction = 'left', path, text } = props;

--- a/amundsen_application/static/js/components/common/EntityCard/index.tsx
+++ b/amundsen_application/static/js/components/common/EntityCard/index.tsx
@@ -11,7 +11,7 @@ export interface EntityCardProps {
   sections: EntityCardSectionProps[];
 }
 
-const EntityCard: React.SFC<EntityCardProps> = ({
+const EntityCard: React.FC<EntityCardProps> = ({
   sections,
 }: EntityCardProps) => {
   const cardItems = sections.map((entry, index) => {

--- a/amundsen_application/static/js/components/common/Flag/index.tsx
+++ b/amundsen_application/static/js/components/common/Flag/index.tsx
@@ -33,7 +33,7 @@ export function convertText(str: string, caseType: string): string {
   }
 }
 
-const Flag: React.SFC<FlagProps> = ({
+const Flag: React.FC<FlagProps> = ({
   caseType,
   text,
   labelStyle,

--- a/amundsen_application/static/js/components/common/FlashMessage/index.tsx
+++ b/amundsen_application/static/js/components/common/FlashMessage/index.tsx
@@ -12,7 +12,7 @@ export interface FlashMessageProps {
   onClose: (event: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
-const FlashMessage: React.SFC<FlashMessageProps> = ({
+const FlashMessage: React.FC<FlashMessageProps> = ({
   iconClass,
   message,
   onClose,

--- a/amundsen_application/static/js/components/common/InfoButton/index.tsx
+++ b/amundsen_application/static/js/components/common/InfoButton/index.tsx
@@ -19,7 +19,7 @@ export interface InfoButtonProps {
   size?: string;
 }
 
-const InfoButton: React.SFC<InfoButtonProps> = ({
+const InfoButton: React.FC<InfoButtonProps> = ({
   title,
   infoText,
   placement,

--- a/amundsen_application/static/js/components/common/Inputs/CheckBoxItem/index.tsx
+++ b/amundsen_application/static/js/components/common/Inputs/CheckBoxItem/index.tsx
@@ -15,7 +15,7 @@ export interface CheckBoxItemProps {
   children: React.ReactNode;
 }
 
-const CheckBoxItem: React.SFC<CheckBoxItemProps> = ({
+const CheckBoxItem: React.FC<CheckBoxItemProps> = ({
   checked = false,
   disabled = false,
   name,

--- a/amundsen_application/static/js/components/common/ResourceListItem/SchemaInfo/index.tsx
+++ b/amundsen_application/static/js/components/common/ResourceListItem/SchemaInfo/index.tsx
@@ -12,7 +12,7 @@ export interface SchemaInfoProps {
   placement?: string;
 }
 
-const SchemaInfo: React.SFC<SchemaInfoProps> = ({
+const SchemaInfo: React.FC<SchemaInfoProps> = ({
   schema,
   table,
   desc,

--- a/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
+++ b/amundsen_application/static/js/components/common/SearchBar/InlineSearchResults/ResultItemList/ResultItem/index.tsx
@@ -14,7 +14,7 @@ export interface ResultItemProps {
   type: string;
 }
 
-const ResultItem: React.SFC<ResultItemProps> = ({
+const ResultItem: React.FC<ResultItemProps> = ({
   href,
   iconClass,
   id,

--- a/amundsen_application/static/js/components/common/ShimmeringResourceLoader/index.tsx
+++ b/amundsen_application/static/js/components/common/ShimmeringResourceLoader/index.tsx
@@ -8,7 +8,7 @@ import './styles.scss';
 
 const DEFAULT_REPETITION = 3;
 
-export const ShimmeringResourceItem: React.SFC = () => {
+export const ShimmeringResourceItem: React.FC = () => {
   return (
     <div className="shimmer-resource-loader-item media">
       <div className="media-left media-middle">
@@ -26,7 +26,7 @@ export interface ShimmeringResourceLoaderProps {
   numItems?: number;
 }
 
-const ShimmeringResourceLoader: React.SFC<ShimmeringResourceLoaderProps> = ({
+const ShimmeringResourceLoader: React.FC<ShimmeringResourceLoaderProps> = ({
   numItems = DEFAULT_REPETITION,
 }: ShimmeringResourceLoaderProps) => {
   return (

--- a/amundsen_application/static/js/components/common/ShimmeringTagListLoader/index.tsx
+++ b/amundsen_application/static/js/components/common/ShimmeringTagListLoader/index.tsx
@@ -12,7 +12,7 @@ type ShimmeringTagItemProps = {
   index: number;
 };
 
-export const ShimmeringTagItem: React.SFC<ShimmeringTagItemProps> = ({
+export const ShimmeringTagItem: React.FC<ShimmeringTagItemProps> = ({
   index,
 }: ShimmeringTagItemProps) => {
   return (
@@ -26,7 +26,7 @@ export interface ShimmeringTagListLoaderProps {
   numItems?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
 }
 
-const ShimmeringTagListLoader: React.SFC<ShimmeringTagListLoaderProps> = ({
+const ShimmeringTagListLoader: React.FC<ShimmeringTagListLoaderProps> = ({
   numItems = DEFAULT_REPETITION,
 }: ShimmeringTagListLoaderProps) => {
   return (

--- a/amundsen_application/static/js/components/common/TabsComponent/index.tsx
+++ b/amundsen_application/static/js/components/common/TabsComponent/index.tsx
@@ -19,7 +19,7 @@ interface TabInfo {
   title: string;
 }
 
-const TabsComponent: React.SFC<TabsProps> = ({
+const TabsComponent: React.FC<TabsProps> = ({
   tabs,
   activeKey,
   defaultTab,


### PR DESCRIPTION
### Summary of Changes
Swaps React.SFC (Stateless Functional Component) for React.FC (Functional Component) types

### Why
React.SFC is now deprecated as mentioned [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364). This is a simple cleanup of all mentions to React.SFC in our repo.

### Tests
Ran tests

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
