### PR TITLE
fix: Create separate reducer for last indexed value

### DIFF
--- a/amundsen_application/static/js/components/Footer/index.spec.tsx
+++ b/amundsen_application/static/js/components/Footer/index.spec.tsx
@@ -85,6 +85,6 @@ describe('mapStateToProps', () => {
   });
 
   it('sets lastIndexed on the props', () => {
-    expect(result.lastIndexed).toEqual(globalState.tableMetadata.lastIndexed);
+    expect(result.lastIndexed).toEqual(globalState.lastIndexed.lastIndexed);
   });
 });

--- a/amundsen_application/static/js/components/Footer/index.tsx
+++ b/amundsen_application/static/js/components/Footer/index.tsx
@@ -7,8 +7,8 @@ import { bindActionCreators } from 'redux';
 // TODO: Use css-modules instead of 'import'
 import './styles.scss';
 import { GlobalState } from 'ducks/rootReducer';
-import { getLastIndexed } from 'ducks/tableMetadata/reducer';
-import { GetLastIndexedRequest } from 'ducks/tableMetadata/types';
+import { getLastIndexed } from 'ducks/lastIndexed/reducer';
+import { GetLastIndexedRequest } from 'ducks/lastIndexed/types';
 
 import { formatDateTimeLong } from 'utils/dateUtils';
 
@@ -62,7 +62,7 @@ export class Footer extends React.Component<FooterProps> {
 
 export const mapStateToProps = (state: GlobalState) => {
   return {
-    lastIndexed: state.tableMetadata.lastIndexed,
+    lastIndexed: state.lastIndexed.lastIndexed,
   };
 };
 

--- a/amundsen_application/static/js/components/Footer/index.tsx
+++ b/amundsen_application/static/js/components/Footer/index.tsx
@@ -33,7 +33,9 @@ const ShimmeringFooterLoader: React.FC = () => {
 
 export class Footer extends React.Component<FooterProps> {
   componentDidMount() {
-    this.props.getLastIndexed();
+    const { getLastIndexed } = this.props;
+
+    getLastIndexed();
   }
 
   generateDateTimeString = () => {

--- a/amundsen_application/static/js/ducks/lastIndexed/api/v0.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/api/v0.ts
@@ -10,6 +10,14 @@ export function getLastIndexed() {
   return axios
     .get(`${API_PATH}/get_last_indexed`)
     .then((response: AxiosResponse<LastIndexedAPI>) => {
-      return response.data.timestamp;
+      const { data } = response;
+
+      return data.timestamp;
+    })
+    .catch((e) => {
+      const timestamp = null;
+      return Promise.reject({
+        timestamp,
+      });
     });
 }

--- a/amundsen_application/static/js/ducks/lastIndexed/api/v0.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/api/v0.ts
@@ -1,0 +1,15 @@
+import axios, { AxiosResponse, AxiosError } from 'axios';
+
+export const API_PATH = '/api/metadata/v0';
+
+type MessageAPI = { msg: string };
+
+export type LastIndexedAPI = { timestamp: string } & MessageAPI;
+
+export function getLastIndexed() {
+  return axios
+    .get(`${API_PATH}/get_last_indexed`)
+    .then((response: AxiosResponse<LastIndexedAPI>) => {
+      return response.data.timestamp;
+    });
+}

--- a/amundsen_application/static/js/ducks/lastIndexed/reducer.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/reducer.ts
@@ -1,0 +1,53 @@
+import {
+  GetLastIndexed,
+  GetLastIndexedRequest,
+  GetLastIndexedResponse,
+} from './types';
+
+export interface LastIndexedReducerState {
+  lastIndexed: number;
+}
+export const initialState: LastIndexedReducerState = {
+  lastIndexed: null,
+};
+
+/* ACTIONS */
+export function getLastIndexed(): GetLastIndexedRequest {
+  return { type: GetLastIndexed.REQUEST };
+}
+
+export function getLastIndexedFailure(): GetLastIndexedResponse {
+  return { type: GetLastIndexed.FAILURE };
+}
+
+export function getLastIndexedSuccess(
+  lastIndexedEpoch: number
+): GetLastIndexedResponse {
+  return {
+    type: GetLastIndexed.SUCCESS,
+    payload: {
+      lastIndexedEpoch,
+    },
+  };
+}
+
+/* REDUCER */
+export default function reducer(
+  state: LastIndexedReducerState = initialState,
+  action
+): LastIndexedReducerState {
+  switch (action.type) {
+    case GetLastIndexed.REQUEST:
+      return initialState;
+    case GetLastIndexed.SUCCESS:
+      return {
+        lastIndexed: (<GetLastIndexedResponse>action).payload.lastIndexedEpoch,
+      };
+    case GetLastIndexed.FAILURE:
+      return {
+        lastIndexed: null,
+      };
+    default:
+      return state;
+  }
+}

--- a/amundsen_application/static/js/ducks/lastIndexed/sagas.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/sagas.ts
@@ -9,7 +9,11 @@ export function* getLastIndexedWorker(
 ): SagaIterator {
   try {
     const lastIndexed = yield call(API.getLastIndexed);
-    yield put(getLastIndexedSuccess(lastIndexed));
+    if (lastIndexed) {
+      yield put(getLastIndexedSuccess(lastIndexed));
+    } else {
+      yield put(getLastIndexedFailure());
+    }
   } catch (e) {
     yield put(getLastIndexedFailure());
   }

--- a/amundsen_application/static/js/ducks/lastIndexed/sagas.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/sagas.ts
@@ -1,0 +1,19 @@
+import { SagaIterator } from 'redux-saga';
+import { call, put, takeEvery } from 'redux-saga/effects';
+import * as API from 'ducks/lastIndexed/api/v0';
+import { getLastIndexedFailure, getLastIndexedSuccess } from './reducer';
+import { GetLastIndexed, GetLastIndexedRequest } from './types';
+
+export function* getLastIndexedWorker(
+  action: GetLastIndexedRequest
+): SagaIterator {
+  try {
+    const lastIndexed = yield call(API.getLastIndexed);
+    yield put(getLastIndexedSuccess(lastIndexed));
+  } catch (e) {
+    yield put(getLastIndexedFailure());
+  }
+}
+export function* getLastIndexedWatcher(): SagaIterator {
+  yield takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker);
+}

--- a/amundsen_application/static/js/ducks/lastIndexed/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/tests/index.spec.ts
@@ -1,0 +1,97 @@
+import { testSaga } from 'redux-saga-test-plan';
+
+import * as API from '../api/v0';
+
+import reducer, {
+  getLastIndexed,
+  getLastIndexedFailure,
+  getLastIndexedSuccess,
+  initialState,
+  LastIndexedReducerState,
+} from '../reducer';
+
+import { getLastIndexedWatcher, getLastIndexedWorker } from '../sagas';
+import { GetLastIndexed } from '../types';
+
+describe('lastIndexed ducks', () => {
+  let testEpoch: number;
+
+  beforeAll(() => {
+    testEpoch = 1545925769;
+  });
+
+  describe('actions', () => {
+    it('getLastIndexed - returns the action to get the last indexed date', () => {
+      const action = getLastIndexed();
+      expect(action.type).toBe(GetLastIndexed.REQUEST);
+    });
+
+    it('getLastIndexedFailure - returns the action to process failure', () => {
+      const action = getLastIndexedFailure();
+      expect(action.type).toBe(GetLastIndexed.FAILURE);
+    });
+
+    it('getLastIndexedSuccess - returns the action to process success', () => {
+      const action = getLastIndexedSuccess(testEpoch);
+      const { payload } = action;
+      expect(action.type).toBe(GetLastIndexed.SUCCESS);
+      expect(payload.lastIndexedEpoch).toBe(testEpoch);
+    });
+  });
+
+  describe('reducer', () => {
+    let testState: LastIndexedReducerState;
+    beforeAll(() => {
+      testState = initialState;
+    });
+
+    it('should return the existing state if action is not handled', () => {
+      expect(reducer(testState, { type: 'INVALID.ACTION' })).toEqual(testState);
+    });
+
+    it('should handle GetLastIndexed.FAILURE', () => {
+      expect(reducer(testState, getLastIndexedFailure())).toEqual({
+        lastIndexed: null,
+      });
+    });
+
+    it('should handle GetLastIndexed.SUCCESS', () => {
+      expect(reducer(testState, getLastIndexedSuccess(testEpoch))).toEqual({
+        lastIndexed: testEpoch,
+      });
+    });
+  });
+
+  describe('sagas', () => {
+    describe('getLastIndexedWatcher', () => {
+      it('takes every GetLastIndexed.REQUEST with getLastIndexedWorker', () => {
+        testSaga(getLastIndexedWatcher)
+          .next()
+          .takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker)
+          .next()
+          .isDone();
+      });
+    });
+
+    describe('getLastIndexedWorker', () => {
+      it('executes flow for getting last indexed value', () => {
+        testSaga(getLastIndexedWorker, getLastIndexed())
+          .next()
+          .call(API.getLastIndexed)
+          .next(testEpoch)
+          .put(getLastIndexedSuccess(testEpoch))
+          .next()
+          .isDone();
+      });
+
+      it('handles request error', () => {
+        testSaga(getLastIndexedWorker, getLastIndexed())
+          .next()
+          .throw(new Error())
+          .put(getLastIndexedFailure())
+          .next()
+          .isDone();
+      });
+    });
+  });
+});

--- a/amundsen_application/static/js/ducks/lastIndexed/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/tests/index.spec.ts
@@ -49,6 +49,10 @@ describe('lastIndexed ducks', () => {
       expect(reducer(testState, { type: 'INVALID.ACTION' })).toEqual(testState);
     });
 
+    it('should handle GetLastIndexed.REQUEST', () => {
+      expect(reducer(testState, getLastIndexed())).toEqual(initialState);
+    });
+
     it('should handle GetLastIndexed.FAILURE', () => {
       expect(reducer(testState, getLastIndexedFailure())).toEqual({
         lastIndexed: null,

--- a/amundsen_application/static/js/ducks/lastIndexed/types.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/types.ts
@@ -1,0 +1,14 @@
+export enum GetLastIndexed {
+  REQUEST = 'amundsen/GET_LAST_UPDATED_REQUEST',
+  SUCCESS = 'amundsen/GET_LAST_UPDATED_SUCCESS',
+  FAILURE = 'amundsen/GET_LAST_UPDATED_FAILURE',
+}
+export interface GetLastIndexedRequest {
+  type: GetLastIndexed.REQUEST;
+}
+export interface GetLastIndexedResponse {
+  type: GetLastIndexed.SUCCESS | GetLastIndexed.FAILURE;
+  payload?: {
+    lastIndexedEpoch: number;
+  };
+}

--- a/amundsen_application/static/js/ducks/lastIndexed/types.ts
+++ b/amundsen_application/static/js/ducks/lastIndexed/types.ts
@@ -8,7 +8,9 @@ export interface GetLastIndexedRequest {
 }
 export interface GetLastIndexedResponse {
   type: GetLastIndexed.SUCCESS | GetLastIndexed.FAILURE;
-  payload?: {
-    lastIndexedEpoch: number;
-  };
+  payload?: GetLastIndexedPayload;
+}
+
+export interface GetLastIndexedPayload {
+  lastIndexedEpoch?: number;
 }

--- a/amundsen_application/static/js/ducks/rootReducer.ts
+++ b/amundsen_application/static/js/ducks/rootReducer.ts
@@ -12,6 +12,7 @@ import search, { SearchReducerState } from './search/reducer';
 import tableMetadata, {
   TableMetadataReducerState,
 } from './tableMetadata/reducer';
+import lastIndexed, { LastIndexedReducerState } from './lastIndexed/reducer';
 import tags, { TagsReducerState } from './tags/reducer';
 import user, { UserReducerState } from './user/reducer';
 import bookmarks, { BookmarkReducerState } from './bookmark/reducer';
@@ -28,6 +29,7 @@ export interface GlobalState {
   popularTables: PopularTablesReducerState;
   search: SearchReducerState;
   tableMetadata: TableMetadataReducerState;
+  lastIndexed: LastIndexedReducerState;
   tags: TagsReducerState;
   user: UserReducerState;
 }
@@ -42,6 +44,7 @@ export default combineReducers<GlobalState>({
   popularTables,
   search,
   tableMetadata,
+  lastIndexed,
   tags,
   user,
 });

--- a/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/amundsen_application/static/js/ducks/rootSaga.ts
@@ -44,7 +44,6 @@ import { updateTableOwnerWatcher } from './tableMetadata/owners/sagas';
 import {
   getTableDataWatcher,
   getColumnDescriptionWatcher,
-  // getLastIndexedWatcher,
   getPreviewDataWatcher,
   getTableDescriptionWatcher,
   updateColumnDescriptionWatcher,

--- a/amundsen_application/static/js/ducks/rootSaga.ts
+++ b/amundsen_application/static/js/ducks/rootSaga.ts
@@ -44,12 +44,15 @@ import { updateTableOwnerWatcher } from './tableMetadata/owners/sagas';
 import {
   getTableDataWatcher,
   getColumnDescriptionWatcher,
-  getLastIndexedWatcher,
+  // getLastIndexedWatcher,
   getPreviewDataWatcher,
   getTableDescriptionWatcher,
   updateColumnDescriptionWatcher,
   updateTableDescriptionWatcher,
 } from './tableMetadata/sagas';
+
+// LastIndexed
+import { getLastIndexedWatcher } from './lastIndexed/sagas';
 
 // Tags
 import { getAllTagsWatcher, updateResourceTagsWatcher } from './tags/sagas';
@@ -100,12 +103,13 @@ export default function* rootSaga() {
     // TableDetail
     getTableDataWatcher(),
     getColumnDescriptionWatcher(),
-    getLastIndexedWatcher(),
     getPreviewDataWatcher(),
     getTableDescriptionWatcher(),
     updateColumnDescriptionWatcher(),
     updateTableDescriptionWatcher(),
     updateTableOwnerWatcher(),
+    // LastIndexed
+    getLastIndexedWatcher(),
     // User
     getLoggedInUserWatcher(),
     getUserWatcher(),

--- a/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -31,7 +31,6 @@ export type TableData = TableMetadata & {
   tags: Tag[];
 };
 export type DescriptionAPI = { description: string } & MessageAPI;
-// export type LastIndexedAPI = { timestamp: string } & MessageAPI;
 export type PreviewDataAPI = { previewData: PreviewData } & MessageAPI;
 export type TableDataAPI = { tableData: TableData } & MessageAPI;
 export type RelatedDashboardDataAPI = {
@@ -172,14 +171,6 @@ export function updateColumnDescription(
     source: 'user',
   });
 }
-
-// export function getLastIndexed() {
-//   return axios
-//     .get(`${API_PATH}/get_last_indexed`)
-//     .then((response: AxiosResponse<LastIndexedAPI>) => {
-//       return response.data.timestamp;
-//     });
-// }
 
 export function getPreviewData(queryParams: PreviewQueryParams) {
   return axios({

--- a/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/api/v0.ts
@@ -31,7 +31,7 @@ export type TableData = TableMetadata & {
   tags: Tag[];
 };
 export type DescriptionAPI = { description: string } & MessageAPI;
-export type LastIndexedAPI = { timestamp: string } & MessageAPI;
+// export type LastIndexedAPI = { timestamp: string } & MessageAPI;
 export type PreviewDataAPI = { previewData: PreviewData } & MessageAPI;
 export type TableDataAPI = { tableData: TableData } & MessageAPI;
 export type RelatedDashboardDataAPI = {
@@ -173,13 +173,13 @@ export function updateColumnDescription(
   });
 }
 
-export function getLastIndexed() {
-  return axios
-    .get(`${API_PATH}/get_last_indexed`)
-    .then((response: AxiosResponse<LastIndexedAPI>) => {
-      return response.data.timestamp;
-    });
-}
+// export function getLastIndexed() {
+//   return axios
+//     .get(`${API_PATH}/get_last_indexed`)
+//     .then((response: AxiosResponse<LastIndexedAPI>) => {
+//       return response.data.timestamp;
+//     });
+// }
 
 export function getPreviewData(queryParams: PreviewQueryParams) {
   return axios({

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -24,9 +24,9 @@ import {
   GetColumnDescriptionRequest,
   UpdateColumnDescription,
   UpdateColumnDescriptionRequest,
-  GetLastIndexed,
-  GetLastIndexedRequest,
-  GetLastIndexedResponse,
+  // GetLastIndexed,
+  // GetLastIndexedRequest,
+  // GetLastIndexedResponse,
   GetPreviewData,
   GetPreviewDataRequest,
   GetPreviewDataResponse,
@@ -66,7 +66,7 @@ export const initialTableDataState: TableMetadata = {
 
 export const initialState: TableMetadataReducerState = {
   isLoading: true,
-  lastIndexed: null,
+  // lastIndexed: null,
   preview: initialPreviewState,
   statusCode: null,
   tableData: initialTableDataState,
@@ -231,22 +231,22 @@ export function updateColumnDescription(
   };
 }
 
-export function getLastIndexed(): GetLastIndexedRequest {
-  return { type: GetLastIndexed.REQUEST };
-}
-export function getLastIndexedFailure(): GetLastIndexedResponse {
-  return { type: GetLastIndexed.FAILURE };
-}
-export function getLastIndexedSuccess(
-  lastIndexedEpoch: number
-): GetLastIndexedResponse {
-  return {
-    type: GetLastIndexed.SUCCESS,
-    payload: {
-      lastIndexedEpoch,
-    },
-  };
-}
+// export function getLastIndexed(): GetLastIndexedRequest {
+//   return { type: GetLastIndexed.REQUEST };
+// }
+// export function getLastIndexedFailure(): GetLastIndexedResponse {
+//   return { type: GetLastIndexed.FAILURE };
+// }
+// export function getLastIndexedSuccess(
+//   lastIndexedEpoch: number
+// ): GetLastIndexedResponse {
+//   return {
+//     type: GetLastIndexed.SUCCESS,
+//     payload: {
+//       lastIndexedEpoch,
+//     },
+//   };
+// }
 
 export function getPreviewData(
   queryParams: PreviewQueryParams
@@ -286,7 +286,7 @@ export interface TableMetadataReducerState {
     errorMessage?: string;
   };
   isLoading: boolean;
-  lastIndexed: number;
+  // lastIndexed: number;
   preview: {
     data: PreviewData;
     status: number | null;
@@ -311,10 +311,11 @@ export default function reducer(
         },
       };
     case GetTableData.REQUEST:
-      return {
-        ...initialState,
-        lastIndexed: state.lastIndexed,
-      };
+      return initialState;
+    // return {
+    //   ...initialState,
+    //   lastIndexed: state.lastIndexed,
+    // };
     case GetTableData.FAILURE:
       return {
         ...state,
@@ -344,13 +345,13 @@ export default function reducer(
         ...state,
         tableData: (<GetColumnDescriptionResponse>action).payload.tableMetadata,
       };
-    case GetLastIndexed.FAILURE:
-      return { ...state, lastIndexed: null };
-    case GetLastIndexed.SUCCESS:
-      return {
-        ...state,
-        lastIndexed: (<GetLastIndexedResponse>action).payload.lastIndexedEpoch,
-      };
+    // case GetLastIndexed.FAILURE:
+    //   return { ...state, lastIndexed: null };
+    // case GetLastIndexed.SUCCESS:
+    //   return {
+    //     ...state,
+    //     lastIndexed: (<GetLastIndexedResponse>action).payload.lastIndexedEpoch,
+    //   };
     case GetPreviewData.FAILURE:
     case GetPreviewData.SUCCESS:
       return { ...state, preview: (<GetPreviewDataResponse>action).payload };

--- a/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/reducer.ts
@@ -24,9 +24,6 @@ import {
   GetColumnDescriptionRequest,
   UpdateColumnDescription,
   UpdateColumnDescriptionRequest,
-  // GetLastIndexed,
-  // GetLastIndexedRequest,
-  // GetLastIndexedResponse,
   GetPreviewData,
   GetPreviewDataRequest,
   GetPreviewDataResponse,
@@ -66,7 +63,6 @@ export const initialTableDataState: TableMetadata = {
 
 export const initialState: TableMetadataReducerState = {
   isLoading: true,
-  // lastIndexed: null,
   preview: initialPreviewState,
   statusCode: null,
   tableData: initialTableDataState,
@@ -231,23 +227,6 @@ export function updateColumnDescription(
   };
 }
 
-// export function getLastIndexed(): GetLastIndexedRequest {
-//   return { type: GetLastIndexed.REQUEST };
-// }
-// export function getLastIndexedFailure(): GetLastIndexedResponse {
-//   return { type: GetLastIndexed.FAILURE };
-// }
-// export function getLastIndexedSuccess(
-//   lastIndexedEpoch: number
-// ): GetLastIndexedResponse {
-//   return {
-//     type: GetLastIndexed.SUCCESS,
-//     payload: {
-//       lastIndexedEpoch,
-//     },
-//   };
-// }
-
 export function getPreviewData(
   queryParams: PreviewQueryParams
 ): GetPreviewDataRequest {
@@ -286,7 +265,6 @@ export interface TableMetadataReducerState {
     errorMessage?: string;
   };
   isLoading: boolean;
-  // lastIndexed: number;
   preview: {
     data: PreviewData;
     status: number | null;
@@ -312,10 +290,6 @@ export default function reducer(
       };
     case GetTableData.REQUEST:
       return initialState;
-    // return {
-    //   ...initialState,
-    //   lastIndexed: state.lastIndexed,
-    // };
     case GetTableData.FAILURE:
       return {
         ...state,
@@ -345,13 +319,6 @@ export default function reducer(
         ...state,
         tableData: (<GetColumnDescriptionResponse>action).payload.tableMetadata,
       };
-    // case GetLastIndexed.FAILURE:
-    //   return { ...state, lastIndexed: null };
-    // case GetLastIndexed.SUCCESS:
-    //   return {
-    //     ...state,
-    //     lastIndexed: (<GetLastIndexedResponse>action).payload.lastIndexedEpoch,
-    //   };
     case GetPreviewData.FAILURE:
     case GetPreviewData.SUCCESS:
       return { ...state, preview: (<GetPreviewDataResponse>action).payload };

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -11,15 +11,11 @@ import {
   getTableDescriptionSuccess,
   getColumnDescriptionFailure,
   getColumnDescriptionSuccess,
-  // getLastIndexedFailure,
-  // getLastIndexedSuccess,
   getPreviewDataFailure,
   getPreviewDataSuccess,
 } from './reducer';
 
 import {
-  // GetLastIndexed,
-  // GetLastIndexedRequest,
   GetPreviewData,
   GetPreviewDataRequest,
   GetTableData,
@@ -163,20 +159,6 @@ export function* updateColumnDescriptionWatcher(): SagaIterator {
     updateColumnDescriptionWorker
   );
 }
-
-// export function* getLastIndexedWorker(
-//   action: GetLastIndexedRequest
-// ): SagaIterator {
-//   try {
-//     const lastIndexed = yield call(API.getLastIndexed);
-//     yield put(getLastIndexedSuccess(lastIndexed));
-//   } catch (e) {
-//     yield put(getLastIndexedFailure());
-//   }
-// }
-// export function* getLastIndexedWatcher(): SagaIterator {
-//   yield takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker);
-// }
 
 export function* getPreviewDataWorker(
   action: GetPreviewDataRequest

--- a/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/sagas.ts
@@ -11,15 +11,15 @@ import {
   getTableDescriptionSuccess,
   getColumnDescriptionFailure,
   getColumnDescriptionSuccess,
-  getLastIndexedFailure,
-  getLastIndexedSuccess,
+  // getLastIndexedFailure,
+  // getLastIndexedSuccess,
   getPreviewDataFailure,
   getPreviewDataSuccess,
 } from './reducer';
 
 import {
-  GetLastIndexed,
-  GetLastIndexedRequest,
+  // GetLastIndexed,
+  // GetLastIndexedRequest,
   GetPreviewData,
   GetPreviewDataRequest,
   GetTableData,
@@ -164,19 +164,19 @@ export function* updateColumnDescriptionWatcher(): SagaIterator {
   );
 }
 
-export function* getLastIndexedWorker(
-  action: GetLastIndexedRequest
-): SagaIterator {
-  try {
-    const lastIndexed = yield call(API.getLastIndexed);
-    yield put(getLastIndexedSuccess(lastIndexed));
-  } catch (e) {
-    yield put(getLastIndexedFailure());
-  }
-}
-export function* getLastIndexedWatcher(): SagaIterator {
-  yield takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker);
-}
+// export function* getLastIndexedWorker(
+//   action: GetLastIndexedRequest
+// ): SagaIterator {
+//   try {
+//     const lastIndexed = yield call(API.getLastIndexed);
+//     yield put(getLastIndexedSuccess(lastIndexed));
+//   } catch (e) {
+//     yield put(getLastIndexedFailure());
+//   }
+// }
+// export function* getLastIndexedWatcher(): SagaIterator {
+//   yield takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker);
+// }
 
 export function* getPreviewDataWorker(
   action: GetPreviewDataRequest

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -28,9 +28,9 @@ import reducer, {
   getColumnDescriptionFailure,
   getColumnDescriptionSuccess,
   updateColumnDescription,
-  getLastIndexed,
-  getLastIndexedFailure,
-  getLastIndexedSuccess,
+  // getLastIndexed,
+  // getLastIndexedFailure,
+  // getLastIndexedSuccess,
   getPreviewData,
   getPreviewDataFailure,
   getPreviewDataSuccess,
@@ -51,8 +51,8 @@ import {
   getColumnDescriptionWorker,
   updateColumnDescriptionWatcher,
   updateColumnDescriptionWorker,
-  getLastIndexedWatcher,
-  getLastIndexedWorker,
+  // getLastIndexedWatcher,
+  // getLastIndexedWorker,
   getPreviewDataWatcher,
   getPreviewDataWorker,
 } from '../sagas';
@@ -63,7 +63,7 @@ import {
   UpdateTableDescription,
   GetColumnDescription,
   UpdateColumnDescription,
-  GetLastIndexed,
+  // GetLastIndexed,
   GetPreviewData,
 } from '../types';
 
@@ -84,7 +84,7 @@ describe('tableMetadata ducks', () => {
   let newDescription: string;
   let previewData: PreviewData;
   let queryParams: PreviewQueryParams;
-  let testEpoch: number;
+  // let testEpoch: number;
   beforeAll(() => {
     expectedData = globalState.tableMetadata.tableData;
     expectedOwners = {
@@ -130,7 +130,7 @@ describe('tableMetadata ducks', () => {
       schema: 'testSchema',
       tableName: 'testName',
     };
-    testEpoch = 1545925769;
+    // testEpoch = 1545925769;
   });
 
   describe('actions', () => {
@@ -245,22 +245,22 @@ describe('tableMetadata ducks', () => {
       expect(payload.onFailure).toBe(mockFailure);
     });
 
-    it('getLastIndexed - returns the action to get the last indexed date of the table', () => {
-      const action = getLastIndexed();
-      expect(action.type).toBe(GetLastIndexed.REQUEST);
-    });
-
-    it('getLastIndexedFailure - returns the action to process failure', () => {
-      const action = getLastIndexedFailure();
-      expect(action.type).toBe(GetLastIndexed.FAILURE);
-    });
-
-    it('getLastIndexedSuccess - returns the action to process success', () => {
-      const action = getLastIndexedSuccess(testEpoch);
-      const { payload } = action;
-      expect(action.type).toBe(GetLastIndexed.SUCCESS);
-      expect(payload.lastIndexedEpoch).toBe(testEpoch);
-    });
+    // it('getLastIndexed - returns the action to get the last indexed date of the table', () => {
+    //   const action = getLastIndexed();
+    //   expect(action.type).toBe(GetLastIndexed.REQUEST);
+    // });
+    //
+    // it('getLastIndexedFailure - returns the action to process failure', () => {
+    //   const action = getLastIndexedFailure();
+    //   expect(action.type).toBe(GetLastIndexed.FAILURE);
+    // });
+    //
+    // it('getLastIndexedSuccess - returns the action to process success', () => {
+    //   const action = getLastIndexedSuccess(testEpoch);
+    //   const { payload } = action;
+    //   expect(action.type).toBe(GetLastIndexed.SUCCESS);
+    //   expect(payload.lastIndexedEpoch).toBe(testEpoch);
+    // });
 
     it('getPreviewData - returns the action to get the preview table data', () => {
       const action = getPreviewData(queryParams);
@@ -352,19 +352,19 @@ describe('tableMetadata ducks', () => {
       });
     });
 
-    it('should handle GetLastIndexed.FAILURE', () => {
-      expect(reducer(testState, getLastIndexedFailure())).toEqual({
-        ...testState,
-        lastIndexed: null,
-      });
-    });
-
-    it('should handle GetLastIndexed.SUCCESS', () => {
-      expect(reducer(testState, getLastIndexedSuccess(testEpoch))).toEqual({
-        ...testState,
-        lastIndexed: testEpoch,
-      });
-    });
+    // it('should handle GetLastIndexed.FAILURE', () => {
+    //   expect(reducer(testState, getLastIndexedFailure())).toEqual({
+    //     ...testState,
+    //     lastIndexed: null,
+    //   });
+    // });
+    //
+    // it('should handle GetLastIndexed.SUCCESS', () => {
+    //   expect(reducer(testState, getLastIndexedSuccess(testEpoch))).toEqual({
+    //     ...testState,
+    //     lastIndexed: testEpoch,
+    //   });
+    // });
 
     it('should handle GetPreviewData.FAILURE', () => {
       const action = getPreviewDataFailure({}, 500);
@@ -720,36 +720,36 @@ describe('tableMetadata ducks', () => {
       });
     });
 
-    describe('getLastIndexedWatcher', () => {
-      it('takes every GetLastIndexed.REQUEST with getLastIndexedWorker', () => {
-        testSaga(getLastIndexedWatcher)
-          .next()
-          .takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker)
-          .next()
-          .isDone();
-      });
-    });
-
-    describe('getLastIndexedWorker', () => {
-      it('executes flow for getting last indexed value', () => {
-        testSaga(getLastIndexedWorker, getLastIndexed())
-          .next()
-          .call(API.getLastIndexed)
-          .next(testEpoch)
-          .put(getLastIndexedSuccess(testEpoch))
-          .next()
-          .isDone();
-      });
-
-      it('handles request error', () => {
-        testSaga(getLastIndexedWorker, getLastIndexed())
-          .next()
-          .throw(new Error())
-          .put(getLastIndexedFailure())
-          .next()
-          .isDone();
-      });
-    });
+    // describe('getLastIndexedWatcher', () => {
+    //   it('takes every GetLastIndexed.REQUEST with getLastIndexedWorker', () => {
+    //     testSaga(getLastIndexedWatcher)
+    //       .next()
+    //       .takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker)
+    //       .next()
+    //       .isDone();
+    //   });
+    // });
+    //
+    // describe('getLastIndexedWorker', () => {
+    //   it('executes flow for getting last indexed value', () => {
+    //     testSaga(getLastIndexedWorker, getLastIndexed())
+    //       .next()
+    //       .call(API.getLastIndexed)
+    //       .next(testEpoch)
+    //       .put(getLastIndexedSuccess(testEpoch))
+    //       .next()
+    //       .isDone();
+    //   });
+    //
+    //   it('handles request error', () => {
+    //     testSaga(getLastIndexedWorker, getLastIndexed())
+    //       .next()
+    //       .throw(new Error())
+    //       .put(getLastIndexedFailure())
+    //       .next()
+    //       .isDone();
+    //   });
+    // });
 
     describe('getPreviewDataWatcher', () => {
       it('takes every GetPreviewData.REQUEST with getPreviewDataWorker', () => {

--- a/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/tests/index.spec.ts
@@ -28,9 +28,6 @@ import reducer, {
   getColumnDescriptionFailure,
   getColumnDescriptionSuccess,
   updateColumnDescription,
-  // getLastIndexed,
-  // getLastIndexedFailure,
-  // getLastIndexedSuccess,
   getPreviewData,
   getPreviewDataFailure,
   getPreviewDataSuccess,
@@ -51,8 +48,6 @@ import {
   getColumnDescriptionWorker,
   updateColumnDescriptionWatcher,
   updateColumnDescriptionWorker,
-  // getLastIndexedWatcher,
-  // getLastIndexedWorker,
   getPreviewDataWatcher,
   getPreviewDataWorker,
 } from '../sagas';
@@ -63,7 +58,6 @@ import {
   UpdateTableDescription,
   GetColumnDescription,
   UpdateColumnDescription,
-  // GetLastIndexed,
   GetPreviewData,
 } from '../types';
 
@@ -84,7 +78,6 @@ describe('tableMetadata ducks', () => {
   let newDescription: string;
   let previewData: PreviewData;
   let queryParams: PreviewQueryParams;
-  // let testEpoch: number;
   beforeAll(() => {
     expectedData = globalState.tableMetadata.tableData;
     expectedOwners = {
@@ -130,7 +123,6 @@ describe('tableMetadata ducks', () => {
       schema: 'testSchema',
       tableName: 'testName',
     };
-    // testEpoch = 1545925769;
   });
 
   describe('actions', () => {
@@ -245,23 +237,6 @@ describe('tableMetadata ducks', () => {
       expect(payload.onFailure).toBe(mockFailure);
     });
 
-    // it('getLastIndexed - returns the action to get the last indexed date of the table', () => {
-    //   const action = getLastIndexed();
-    //   expect(action.type).toBe(GetLastIndexed.REQUEST);
-    // });
-    //
-    // it('getLastIndexedFailure - returns the action to process failure', () => {
-    //   const action = getLastIndexedFailure();
-    //   expect(action.type).toBe(GetLastIndexed.FAILURE);
-    // });
-    //
-    // it('getLastIndexedSuccess - returns the action to process success', () => {
-    //   const action = getLastIndexedSuccess(testEpoch);
-    //   const { payload } = action;
-    //   expect(action.type).toBe(GetLastIndexed.SUCCESS);
-    //   expect(payload.lastIndexedEpoch).toBe(testEpoch);
-    // });
-
     it('getPreviewData - returns the action to get the preview table data', () => {
       const action = getPreviewData(queryParams);
       const { payload } = action;
@@ -351,20 +326,6 @@ describe('tableMetadata ducks', () => {
         tableData: expectedData,
       });
     });
-
-    // it('should handle GetLastIndexed.FAILURE', () => {
-    //   expect(reducer(testState, getLastIndexedFailure())).toEqual({
-    //     ...testState,
-    //     lastIndexed: null,
-    //   });
-    // });
-    //
-    // it('should handle GetLastIndexed.SUCCESS', () => {
-    //   expect(reducer(testState, getLastIndexedSuccess(testEpoch))).toEqual({
-    //     ...testState,
-    //     lastIndexed: testEpoch,
-    //   });
-    // });
 
     it('should handle GetPreviewData.FAILURE', () => {
       const action = getPreviewDataFailure({}, 500);
@@ -719,37 +680,6 @@ describe('tableMetadata ducks', () => {
         });
       });
     });
-
-    // describe('getLastIndexedWatcher', () => {
-    //   it('takes every GetLastIndexed.REQUEST with getLastIndexedWorker', () => {
-    //     testSaga(getLastIndexedWatcher)
-    //       .next()
-    //       .takeEvery(GetLastIndexed.REQUEST, getLastIndexedWorker)
-    //       .next()
-    //       .isDone();
-    //   });
-    // });
-    //
-    // describe('getLastIndexedWorker', () => {
-    //   it('executes flow for getting last indexed value', () => {
-    //     testSaga(getLastIndexedWorker, getLastIndexed())
-    //       .next()
-    //       .call(API.getLastIndexed)
-    //       .next(testEpoch)
-    //       .put(getLastIndexedSuccess(testEpoch))
-    //       .next()
-    //       .isDone();
-    //   });
-    //
-    //   it('handles request error', () => {
-    //     testSaga(getLastIndexedWorker, getLastIndexed())
-    //       .next()
-    //       .throw(new Error())
-    //       .put(getLastIndexedFailure())
-    //       .next()
-    //       .isDone();
-    //   });
-    // });
 
     describe('getPreviewDataWatcher', () => {
       it('takes every GetPreviewData.REQUEST with getPreviewDataWorker', () => {

--- a/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -116,21 +116,6 @@ export interface UpdateColumnDescriptionResponse {
   type: UpdateColumnDescription.SUCCESS | UpdateColumnDescription.FAILURE;
 }
 
-// export enum GetLastIndexed {
-//   REQUEST = 'amundsen/tableMetadata/GET_LAST_UPDATED_REQUEST',
-//   SUCCESS = 'amundsen/tableMetadata/GET_LAST_UPDATED_SUCCESS',
-//   FAILURE = 'amundsen/tableMetadata/GET_LAST_UPDATED_FAILURE',
-// }
-// export interface GetLastIndexedRequest {
-//   type: GetLastIndexed.REQUEST;
-// }
-// export interface GetLastIndexedResponse {
-//   type: GetLastIndexed.SUCCESS | GetLastIndexed.FAILURE;
-//   payload?: {
-//     lastIndexedEpoch: number;
-//   };
-// }
-
 export enum GetPreviewData {
   REQUEST = 'amundsen/preview/GET_PREVIEW_DATA_REQUEST',
   SUCCESS = 'amundsen/preview/GET_PREVIEW_DATA_SUCCESS',

--- a/amundsen_application/static/js/ducks/tableMetadata/types.ts
+++ b/amundsen_application/static/js/ducks/tableMetadata/types.ts
@@ -116,20 +116,20 @@ export interface UpdateColumnDescriptionResponse {
   type: UpdateColumnDescription.SUCCESS | UpdateColumnDescription.FAILURE;
 }
 
-export enum GetLastIndexed {
-  REQUEST = 'amundsen/tableMetadata/GET_LAST_UPDATED_REQUEST',
-  SUCCESS = 'amundsen/tableMetadata/GET_LAST_UPDATED_SUCCESS',
-  FAILURE = 'amundsen/tableMetadata/GET_LAST_UPDATED_FAILURE',
-}
-export interface GetLastIndexedRequest {
-  type: GetLastIndexed.REQUEST;
-}
-export interface GetLastIndexedResponse {
-  type: GetLastIndexed.SUCCESS | GetLastIndexed.FAILURE;
-  payload?: {
-    lastIndexedEpoch: number;
-  };
-}
+// export enum GetLastIndexed {
+//   REQUEST = 'amundsen/tableMetadata/GET_LAST_UPDATED_REQUEST',
+//   SUCCESS = 'amundsen/tableMetadata/GET_LAST_UPDATED_SUCCESS',
+//   FAILURE = 'amundsen/tableMetadata/GET_LAST_UPDATED_FAILURE',
+// }
+// export interface GetLastIndexedRequest {
+//   type: GetLastIndexed.REQUEST;
+// }
+// export interface GetLastIndexedResponse {
+//   type: GetLastIndexed.SUCCESS | GetLastIndexed.FAILURE;
+//   payload?: {
+//     lastIndexedEpoch: number;
+//   };
+// }
 
 export enum GetPreviewData {
   REQUEST = 'amundsen/preview/GET_PREVIEW_DATA_REQUEST',

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -148,7 +148,7 @@ const globalState: GlobalState = {
   },
   tableMetadata: {
     isLoading: true,
-    lastIndexed: 1555632106,
+    // lastIndexed: 1555632106,
     preview: {
       data: {},
       status: null,
@@ -179,6 +179,7 @@ const globalState: GlobalState = {
       owners: {},
     },
   },
+  lastIndexed: { lastIndexed: 1555632106 },
   tags: {
     allTags: {
       isLoading: false,

--- a/amundsen_application/static/js/fixtures/globalState.ts
+++ b/amundsen_application/static/js/fixtures/globalState.ts
@@ -148,7 +148,6 @@ const globalState: GlobalState = {
   },
   tableMetadata: {
     isLoading: true,
-    // lastIndexed: 1555632106,
     preview: {
       data: {},
       status: null,


### PR DESCRIPTION
### Summary of Changes

Currently single reducer is handling states related to tableMetadata and lastIndexed values. To optimize, we decoupled tableMetadata and lastIndexed values and created different reducer to handle lastIndexed state.

### Tests
Added unit tests

### Documentation

NA

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
