### PR TITLE
fix: OwnerEditor readOnly support

### DIFF
--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/constants.ts
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/constants.ts
@@ -2,10 +2,9 @@ export const DEFAULT_ERROR_TEXT =
   'There was a problem with the request, please reload the page.';
 export const USERID_LABEL = 'email address';
 export const ADD_ITEM = 'Add';
+export const ADD_OWNER = 'Add Owner';
 export const DELETE_ITEM = 'Delete Item';
-
 export const NO_OWNER_TEXT = 'No owner';
 export const OWNED_BY = 'Owned By';
-
 export const CANCEL_TEXT = 'Cancel';
 export const SAVE_TEXT = 'Save';

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/constants.ts
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/constants.ts
@@ -3,3 +3,9 @@ export const DEFAULT_ERROR_TEXT =
 export const USERID_LABEL = 'email address';
 export const ADD_ITEM = 'Add';
 export const DELETE_ITEM = 'Delete Item';
+
+export const NO_OWNER_TEXT = 'No owner';
+export const OWNED_BY = 'Owned By';
+
+export const CANCEL_TEXT = 'Cancel';
+export const SAVE_TEXT = 'Save';

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
@@ -30,11 +30,20 @@ describe('OwnerEditor', () => {
   };
 
   describe('render', () => {
-    it('renders text if no owners', () => {
-      const { wrapper } = setup();
-      expect(wrapper.find(AvatarLabel).text()).toContain(
-        Constants.NO_OWNER_TEXT
-      );
+    describe('when no owners', () => {
+      it('renders text if readOnly', () => {
+        const { wrapper } = setup({ readOnly: true });
+        expect(wrapper.find(AvatarLabel).text()).toContain(
+          Constants.NO_OWNER_TEXT
+        );
+      });
+
+      it('renders add button if not readOnly', () => {
+        const { wrapper } = setup();
+        expect(wrapper.find('.add-item-button').text()).toContain(
+          Constants.ADD_OWNER
+        );
+      });
     });
 
     it('renders owners if they exist', () => {

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import { mount } from 'enzyme';
+
+import globalState from 'fixtures/globalState';
+import AvatarLabel from 'components/common/AvatarLabel';
+
+import {
+  OwnerEditor,
+  OwnerEditorProps,
+  mapStateToProps,
+  mapDispatchToProps,
+} from '.';
+import * as Constants from './constants';
+
+describe('OwnerEditor', () => {
+  const setup = (propOverrides?: Partial<OwnerEditorProps>) => {
+    const props: OwnerEditorProps = {
+      errorText: null,
+      isLoading: false,
+      itemProps: {},
+      isEditing: null,
+      setEditMode: jest.fn(),
+      onUpdateList: jest.fn(),
+      readOnly: null,
+      ...propOverrides,
+    };
+    const wrapper = mount<OwnerEditor>(<OwnerEditor {...props} />);
+    return { props, wrapper };
+  };
+
+  describe('render', () => {
+    it('renders text if no owners', () => {
+      const { wrapper } = setup({ itemProps: {} });
+      expect(wrapper.find(AvatarLabel).text()).toContain(Constants.NO_OWNER_TEXT));
+    });
+
+    it('renders owners if they exist', () => {
+      const { wrapper } = setup({
+        itemProps: { owner1: {}, owner2: {}, owner3: {} },
+      });
+      expect(wrapper.find(AvatarLabel).length).toBe(3);
+    });
+  });
+});

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.spec.tsx
@@ -31,8 +31,10 @@ describe('OwnerEditor', () => {
 
   describe('render', () => {
     it('renders text if no owners', () => {
-      const { wrapper } = setup({ itemProps: {} });
-      expect(wrapper.find(AvatarLabel).text()).toContain(Constants.NO_OWNER_TEXT));
+      const { wrapper } = setup();
+      expect(wrapper.find(AvatarLabel).text()).toContain(
+        Constants.NO_OWNER_TEXT
+      );
     });
 
     it('renders owners if they exist', () => {
@@ -40,6 +42,18 @@ describe('OwnerEditor', () => {
         itemProps: { owner1: {}, owner2: {}, owner3: {} },
       });
       expect(wrapper.find(AvatarLabel).length).toBe(3);
+    });
+
+    describe('editing modal', () => {
+      it('renders when not readOnly', () => {
+        const { wrapper } = setup();
+        expect(wrapper.find('.owner-editor-modal').exists()).toBe(true);
+      });
+
+      it('does not render when readOnly', () => {
+        const { wrapper } = setup({ readOnly: true });
+        expect(wrapper.find('.owner-editor-modal').exists()).toBe(false);
+      });
     });
   });
 });

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -90,6 +90,10 @@ export class OwnerEditor extends React.Component<
     }
   }
 
+  handleShow = () => {
+    this.props.setEditMode(true);
+  };
+
   cancelEdit = () => {
     this.setState({ tempItemProps: this.state.itemProps });
     this.props.setEditMode(false);
@@ -246,17 +250,27 @@ export class OwnerEditor extends React.Component<
           return <li key={`list-item:${key}`}>{listItem}</li>;
         })}
       </ul>
-    ) : (
-      <AvatarLabel
-        avatarClass="gray-avatar"
-        labelClass="text-placeholder"
-        label={Constants.NO_OWNER_TEXT}
-      />
-    );
+    ) : null;
 
     return (
       <div className="owner-editor-component">
         {ownerList}
+        {this.props.readOnly && !hasItems && (
+          <AvatarLabel
+            avatarClass="gray-avatar"
+            labelClass="text-placeholder"
+            label={Constants.NO_OWNER_TEXT}
+          />
+        )}
+        {!this.props.readOnly && !hasItems && (
+          <button
+            className="btn btn-flat-icon add-item-button"
+            onClick={this.handleShow}
+          >
+            <img className="icon icon-plus-circle" alt="" />
+            <span>{Constants.ADD_OWNER}</span>
+          </button>
+        )}
         {!this.props.readOnly && (
           <Modal
             className="owner-editor-modal"

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -92,10 +92,6 @@ export class OwnerEditor extends React.Component<
     }
   }
 
-  handleShow = () => {
-    this.props.setEditMode(true);
-  };
-
   cancelEdit = () => {
     this.setState({ tempItemProps: this.state.itemProps });
     this.props.setEditMode(false);
@@ -208,7 +204,7 @@ export class OwnerEditor extends React.Component<
   };
 
   render() {
-    let content;
+    const hasItems = Object.keys(this.state.itemProps).length > 0;
 
     if (this.state.errorText) {
       return (
@@ -218,88 +214,78 @@ export class OwnerEditor extends React.Component<
       );
     }
 
-    if (this.state.itemProps.size === 0) {
-      content = <label className="status-message">No entries exist</label>;
-    } else {
-      content = (
-        <ul className="component-list">
-          {Object.keys(this.state.itemProps).map((key) => {
-            const owner = this.state.itemProps[key];
-            const avatarLabel = React.createElement(AvatarLabel, owner);
+    const ownerList = hasItems ? (
+      <ul className="component-list">
+        {Object.keys(this.state.itemProps).map((key) => {
+          const owner = this.state.itemProps[key];
+          const avatarLabel = React.createElement(AvatarLabel, owner);
 
-            let listItem;
-            if (owner.link === undefined) {
-              listItem = avatarLabel;
-            } else if (owner.isExternal) {
-              listItem = (
-                <a
-                  href={owner.link}
-                  target="_blank"
-                  id={`table-owners:${key}`}
-                  onClick={logClick}
-                  rel="noreferrer"
-                >
-                  {avatarLabel}
-                </a>
-              );
-            } else {
-              listItem = (
-                <Link
-                  to={owner.link}
-                  id={`table-owners:${key}`}
-                  onClick={logClick}
-                >
-                  {avatarLabel}
-                </Link>
-              );
-            }
-
-            return <li key={`list-item:${key}`}>{listItem}</li>;
-          })}
-        </ul>
-      );
-    }
+          let listItem;
+          if (owner.link === undefined) {
+            listItem = avatarLabel;
+          } else if (owner.isExternal) {
+            listItem = (
+              <a
+                href={owner.link}
+                target="_blank"
+                id={`table-owners:${key}`}
+                onClick={logClick}
+                rel="noreferrer"
+              >
+                {avatarLabel}
+              </a>
+            );
+          } else {
+            listItem = (
+              <Link
+                to={owner.link}
+                id={`table-owners:${key}`}
+                onClick={logClick}
+              >
+                {avatarLabel}
+              </Link>
+            );
+          }
+          return <li key={`list-item:${key}`}>{listItem}</li>;
+        })}
+      </ul>
+    ) : (
+      <AvatarLabel
+        avatarClass="gray-avatar"
+        labelClass="text-placeholder"
+        label={Constants.NO_OWNER_TEXT}
+      />
+    );
 
     return (
       <div className="owner-editor-component">
-        {content}
-        {!this.state.readOnly &&
-          Object.keys(this.state.itemProps).length === 0 && (
-            <button
-              className="btn btn-flat-icon add-item-button"
-              onClick={this.handleShow}
-            >
-              <img className="icon icon-plus-circle" alt="" />
-              <span>Add Owner</span>
-            </button>
-          )}
-
+        {ownerList}
         <Modal
-          className="owner-editor-modal"
-          show={this.props.isEditing}
-          onHide={this.cancelEdit}
+         className="owner-editor-modal"
+         show={this.props.isEditing}
+         onHide={this.cancelEdit}
         >
-          <Modal.Header className="text-center" closeButton={false}>
-            <Modal.Title>Owned By</Modal.Title>
-          </Modal.Header>
-          {this.renderModalBody()}
-          <Modal.Footer>
-            <button
-              type="button"
-              className="btn btn-default"
-              onClick={this.cancelEdit}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={this.saveEdit}
-            >
-              Save
-            </button>
-          </Modal.Footer>
-        </Modal>
+         <Modal.Header className="text-center" closeButton={false}>
+           <Modal.Title>{Constants.OWNED_BY}</Modal.Title>
+         </Modal.Header>
+         {this.renderModalBody()}
+         <Modal.Footer>
+           <button
+             type="button"
+             className="btn btn-default"
+             onClick={this.cancelEdit}
+           >
+             {Constants.CANCEL_TEXT}
+           </button>
+           <button
+             type="button"
+             className="btn btn-primary"
+             onClick={this.saveEdit}
+           >
+             {Constants.SAVE_TEXT}
+           </button>
+         </Modal.Footer>
+       </Modal>
       </div>
     );
   }

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -44,7 +44,7 @@ export interface StateFromProps {
   itemProps: { [id: string]: OwnerAvatarLabelProps };
 }
 
-type OwnerEditorProps = ComponentProps &
+export type OwnerEditorProps = ComponentProps &
   DispatchFromProps &
   StateFromProps &
   EditableSectionChildProps;
@@ -52,7 +52,6 @@ type OwnerEditorProps = ComponentProps &
 interface OwnerEditorState {
   errorText: string | null;
   itemProps: { [id: string]: OwnerAvatarLabelProps };
-  readOnly: boolean;
   tempItemProps: { [id: string]: AvatarLabelProps };
 }
 
@@ -75,7 +74,6 @@ export class OwnerEditor extends React.Component<
     this.state = {
       errorText: props.errorText,
       itemProps: props.itemProps,
-      readOnly: props.readOnly,
       tempItemProps: props.itemProps,
     };
 
@@ -116,7 +114,6 @@ export class OwnerEditor extends React.Component<
     const onFailureCallback = () => {
       this.setState({
         errorText: Constants.DEFAULT_ERROR_TEXT,
-        readOnly: true,
       });
       this.props.setEditMode(false);
     };
@@ -260,32 +257,34 @@ export class OwnerEditor extends React.Component<
     return (
       <div className="owner-editor-component">
         {ownerList}
-        <Modal
-         className="owner-editor-modal"
-         show={this.props.isEditing}
-         onHide={this.cancelEdit}
-        >
-         <Modal.Header className="text-center" closeButton={false}>
-           <Modal.Title>{Constants.OWNED_BY}</Modal.Title>
-         </Modal.Header>
-         {this.renderModalBody()}
-         <Modal.Footer>
-           <button
-             type="button"
-             className="btn btn-default"
-             onClick={this.cancelEdit}
-           >
-             {Constants.CANCEL_TEXT}
-           </button>
-           <button
-             type="button"
-             className="btn btn-primary"
-             onClick={this.saveEdit}
-           >
-             {Constants.SAVE_TEXT}
-           </button>
-         </Modal.Footer>
-       </Modal>
+        {!this.props.readOnly && (
+          <Modal
+            className="owner-editor-modal"
+            show={this.props.isEditing}
+            onHide={this.cancelEdit}
+          >
+            <Modal.Header className="text-center" closeButton={false}>
+              <Modal.Title>{Constants.OWNED_BY}</Modal.Title>
+            </Modal.Header>
+            {this.renderModalBody()}
+            <Modal.Footer>
+              <button
+                type="button"
+                className="btn btn-default"
+                onClick={this.cancelEdit}
+              >
+                {Constants.CANCEL_TEXT}
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={this.saveEdit}
+              >
+                {Constants.SAVE_TEXT}
+              </button>
+            </Modal.Footer>
+          </Modal>
+        )}
       </div>
     );
   }

--- a/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
+++ b/amundsen_application/static/js/components/TableDetail/OwnerEditor/index.tsx
@@ -231,7 +231,7 @@ export class OwnerEditor extends React.Component<
                 target="_blank"
                 id={`table-owners:${key}`}
                 onClick={logClick}
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 {avatarLabel}
               </a>
@@ -264,6 +264,7 @@ export class OwnerEditor extends React.Component<
         )}
         {!this.props.readOnly && !hasItems && (
           <button
+            type="button"
             className="btn btn-flat-icon add-item-button"
             onClick={this.handleShow}
           >

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -110,9 +110,9 @@ export class EditableSection extends React.Component<
   };
 
   render() {
-    const { title, readOnly = false } = this.props;
+    const { children, title, readOnly = false } = this.props;
     const childrenWithProps = React.Children.map(
-      this.props.children,
+      children,
       (child) => {
         if (!React.isValidElement(child)) {
           return child;

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -110,8 +110,9 @@ export class EditableSection extends React.Component<
 
   render() {
     const { title, readOnly = false } = this.props;
-    const childrenWithProps = !readOnly
-      ? React.Children.map(this.props.children, (child) => {
+    const childrenWithProps = React.Children.map(
+      this.props.children,
+      (child) => {
           if (!React.isValidElement(child)) {
             return child;
           }
@@ -120,8 +121,7 @@ export class EditableSection extends React.Component<
             isEditing: this.state.isEditing,
             setEditMode: this.setEditMode,
           });
-        })
-      : this.props.children;
+        });
 
     return (
       <section className="editable-section">

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -24,6 +24,7 @@ interface EditableSectionState {
 export interface EditableSectionChildProps {
   isEditing?: boolean;
   setEditMode?: (isEditing: boolean) => void;
+  readOnly?: boolean;
 }
 
 export class EditableSection extends React.Component<
@@ -113,15 +114,16 @@ export class EditableSection extends React.Component<
     const childrenWithProps = React.Children.map(
       this.props.children,
       (child) => {
-          if (!React.isValidElement(child)) {
-            return child;
-          }
+        if (!React.isValidElement(child)) {
+          return child;
+        }
 
-          return React.cloneElement(child, {
-            isEditing: this.state.isEditing,
-            setEditMode: this.setEditMode,
-          });
+        return React.cloneElement(child, {
+          isEditing: this.state.isEditing,
+          setEditMode: this.setEditMode,
         });
+      }
+    );
 
     return (
       <section className="editable-section">

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -111,20 +111,17 @@ export class EditableSection extends React.Component<
 
   render() {
     const { children, title, readOnly = false } = this.props;
-    const childrenWithProps = React.Children.map(
-      children,
-      (child) => {
-        if (!React.isValidElement(child)) {
-          return child;
-        }
-
-        return React.cloneElement(child, {
-          readOnly,
-          isEditing: this.state.isEditing,
-          setEditMode: this.setEditMode,
-        });
+    const childrenWithProps = React.Children.map(children, (child) => {
+      if (!React.isValidElement(child)) {
+        return child;
       }
-    );
+
+      return React.cloneElement(child, {
+        readOnly,
+        isEditing: this.state.isEditing,
+        setEditMode: this.setEditMode,
+      });
+    });
 
     return (
       <section className="editable-section">

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -119,6 +119,7 @@ export class EditableSection extends React.Component<
         }
 
         return React.cloneElement(child, {
+          readOnly,
           isEditing: this.state.isEditing,
           setEditMode: this.setEditMode,
         });


### PR DESCRIPTION
### Summary of Changes
1. Update `EditableSection` to correctly pass its `readOnly` state to `OwnerEditor`.  
2. Removed `readOnly` from the `OwnerEditor` component state. It is an artifact from old behavior.
3. Update rendering logic -- when there are no owners on a readOnly `OwnerEditor` we show the updated empty state from our designs.
     <img src='https://user-images.githubusercontent.com/1790900/89674021-3e4db800-d89c-11ea-84a2-e7419531e221.png' width='20%' />

### Tests

Added unit tests for updated render logic.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes, including screenshots of any UI changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
