### PR TITLE
fix: Update EditableSection interaction

### DIFF
--- a/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
@@ -26,7 +26,7 @@ describe('EditableSection', () => {
       preventDefault: jest.fn(),
     };
 
-    it('preventDefault on click if !readOnly', () => {
+    it('preventDefault on click', () => {
       const { wrapper, props } = setup();
       wrapper
         .find('.editable-section-label-wrapper')

--- a/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
@@ -23,15 +23,15 @@ describe('EditableSection', () => {
 
   describe('handleClick', () => {
     const clickEvent = {
-      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
     };
 
-    it('preventDefault on click', () => {
+    it('stopPropagation on click', () => {
       const { wrapper, props } = setup();
       wrapper
         .find('.editable-section-label-wrapper')
         .simulate('click', clickEvent);
-      expect(clickEvent.preventDefault).toHaveBeenCalled();
+      expect(clickEvent.stopPropagation).toHaveBeenCalled();
     });
   });
 

--- a/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.spec.tsx
@@ -23,15 +23,15 @@ describe('EditableSection', () => {
 
   describe('handleClick', () => {
     const clickEvent = {
-      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
     };
 
-    it('stopPropagation on click', () => {
+    it('preventDefault on click if !readOnly', () => {
       const { wrapper, props } = setup();
       wrapper
         .find('.editable-section-label-wrapper')
         .simulate('click', clickEvent);
-      expect(clickEvent.stopPropagation).toHaveBeenCalled();
+      expect(clickEvent.preventDefault).toHaveBeenCalled();
     });
   });
 

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -51,8 +51,8 @@ export class EditableSection extends React.Component<
     this.setState({ isEditing: !this.state.isEditing });
   };
 
-  stopPropagation = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
+  preventDefault = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
   };
 
   static convertText(str: string): string {
@@ -128,7 +128,7 @@ export class EditableSection extends React.Component<
         <label className="editable-section-label">
           <div
             className="editable-section-label-wrapper"
-            onClick={this.stopPropagation}
+            onClick={!readOnly ? this.preventDefault : null}
           >
             <span className="section-title title-3">
               {EditableSection.convertText(title)}

--- a/amundsen_application/static/js/components/common/EditableSection/index.tsx
+++ b/amundsen_application/static/js/components/common/EditableSection/index.tsx
@@ -51,8 +51,8 @@ export class EditableSection extends React.Component<
     this.setState({ isEditing: !this.state.isEditing });
   };
 
-  preventDefault = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
+  stopPropagation = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
   };
 
   static convertText(str: string): string {
@@ -128,7 +128,7 @@ export class EditableSection extends React.Component<
         <label className="editable-section-label">
           <div
             className="editable-section-label-wrapper"
-            onClick={this.preventDefault}
+            onClick={this.stopPropagation}
           >
             <span className="section-title title-3">
               {EditableSection.convertText(title)}


### PR DESCRIPTION
### Summary of Changes

For our desired interaction, we only need to call `preventDefault` when the rendering edit button (`readOnly=false`), and not when rendering the edit link (`readOnly=true`). 

### Tests

N/A

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes, including screenshots of any UI changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public python functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes all tests documented in the [developer guide](https://github.com/lyft/amundsenfrontendlibrary/blob/master/docs/developer_guide.md#testing)
